### PR TITLE
feat(index.html): set lang of tag html to locale

### DIFF
--- a/packages/valaxy/src/client/index.html
+++ b/packages/valaxy/src/client/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="i18n">
+<html class="i18n">
 
 <head>
   <meta charset="UTF-8">
@@ -18,6 +18,7 @@
 
       // document.documentElement.classList.add('dark')
       const locale = localStorage.getItem('valaxy-locale') || 'en'
+      document.getElementsByTagName('html')[0].setAttribute('lang', locale)
       console.log(locale)
       document.documentElement.classList.toggle(locale, true)
     })()


### PR DESCRIPTION
Browsers will recognize this attribute to determine what language a website uses and provide corresponding services like automatically translating.

Maybe some spiders will also get infomartion about a website from this attribute?

However, I think it's necessary for users to use standard language abbreviations when internationalization if set this attribute to locale.