### PR TITLE
fix: reverse slash on windows

### DIFF
--- a/packages/valaxy/src/node/plugins/index.ts
+++ b/packages/valaxy/src/node/plugins/index.ts
@@ -5,7 +5,7 @@ import type { Plugin } from 'vite'
 // import consola from 'consola'
 import { resolveConfig } from '../config'
 import type { ResolvedValaxyOptions, ValaxyServerOptions } from '../options'
-import { toAtFS } from '../utils'
+import { toAtFS, slash } from '../utils'
 import { VALAXY_CONFIG_ID } from './valaxy'
 
 /**
@@ -40,6 +40,10 @@ function generateLocales(roots: string[]) {
   const languages = ['zh-CN', 'en']
 
   roots.forEach((root, i) => {
+    // fix reverse slash on windows
+    if (process.platform === 'win32') {
+      root = slash(root)
+    }
     languages.forEach((lang) => {
       const langYml = `${root}/locales/${lang}.yml`
       if (fs.existsSync(langYml) && fs.readFileSync(langYml, 'utf-8')) {


### PR DESCRIPTION
This only happens on Windows

```
[vite] Internal server error: Failed to resolve import "D:DocumentsProjectalaxy-blog
ode_modules.pnpmalaxy@0.2.3
ode_modulesalaxysrcclient/locales/zh-CN.yml" from "..\..\..\@valaxyjs\locales". Does the file exist?
  Plugin: vite:import-analysis
  File: /@valaxyjs/locales
  1  |  const messages = { "zh-CN": {}, en: {} }
  2  |  import zhCN0 from "D:\Documents\Project\valaxy-blog\node_modules\.pnpm\valaxy@0.2.3\node_modules\valaxy\src\client/locales/zh-CN.yml"
     |                     ^
  3  |  Object.assign(messages['zh-CN'], zhCN0)
  4  |  import en0 from "D:\Documents\Project\valaxy-blog\node_modules\.pnpm\valaxy@0.2.3\node_modules\valaxy\src\client/locales/en.yml"
```

The path was written into a string without escape, which broke the path