### PR TITLE
No complex number in Chinese & Example articles in English

### DIFF
--- a/demo/yun/pages/posts/design.md
+++ b/demo/yun/pages/posts/design.md
@@ -4,6 +4,7 @@ date: 2022-03-29
 end: false
 ---
 
+:::zh-CN
 ## 特点
 
 与 Hexo 相比，没有 `_drafts` 文件夹。（当然自己新建也完全没问题……）
@@ -16,6 +17,22 @@ Valaxy 认为这完全没有必要，您只需在 `frontmatter` 中添加 `draft
 当需要发布时，注释掉它即可。
 
 譬如：
+:::
+
+:::en
+## Features
+
+Compared with Hexo, There is no `_drafts` folder. (Of course, it is no problem to create the folder……)
+
+When writing a blog post under the drafts folder, I had to move back and forth under it and the posts folder to preview the final effect.
+
+Valaxy doesn't think this is necessary at all. You can set it as draft by adding the 'draft: true' attribute to 'frontmatter'.
+Articles with status draft are filtered when building and generating RSS, but you can still preview it at development time.
+
+When you need to publish, just comment it out.
+
+For example:
+:::
 
 ```markdown
 ---
@@ -23,5 +40,5 @@ draft: true
 ---
 ```
 
-也许你可能认为放在对应文件夹下适合快速查找拥有哪些草稿，但是你通过编辑器的全局搜索 `draft: true` 同样可以快速做到。
-并且你还能知道你之前打算把它发布在哪个文件夹（路径）下。
+You may think that putting it in the corresponding folder is suitable for quickly finding which drafts you have, but you can also do it quickly through the editor's global search 'draft: true'.
+And you can also know which folder (path) you planned to publish it in.

--- a/demo/yun/pages/posts/dev.md
+++ b/demo/yun/pages/posts/dev.md
@@ -6,6 +6,12 @@ tags:
   - valaxy
 ---
 
+:::zh-CN
 还什么都没写呢……
+:::
+
+:::en
+Nothing has been written……
+:::
 
 <!-- more -->

--- a/demo/yun/pages/posts/draft.md
+++ b/demo/yun/pages/posts/draft.md
@@ -4,4 +4,10 @@ draft: true
 date: 2022-04-08
 ---
 
+:::zh-CN
 草稿内容
+:::
+
+:::en
+Here is the content of this draft
+:::

--- a/demo/yun/pages/posts/hello-valaxy.md
+++ b/demo/yun/pages/posts/hello-valaxy.md
@@ -9,6 +9,7 @@ tags:
 top: 1
 ---
 
+:::zh-CN
 ## What is Valaxy?
 
 Valaxy 的目标是成为新一代的静态博客框架/生成器。
@@ -23,7 +24,26 @@ Valaxy 的目标是成为新一代的静态博客框架/生成器。
 
 一味地讲述 Valaxy 的优点似乎有些难以理解。
 
-我将会把 Valaxy 与现有的 Hexo（流行的静态博客框架）与 VitePress/VuePress（流行的静态站点生成器）进行对比，并阐述 Valaxy 相比它们的优势。
+我将会把 Valaxy 与现有的 Hexo（流行的静态博客框架）与 VitePress/VuePress（流行的静态站点生成器）进行对比，并阐述 Valaxy 的优势。
+:::
+
+:::en
+## What is Valaxy?
+
+Valaxy aims to be a next generation static blog framework/generator.
+
+## Why Valaxy?
+
+Next Generation Static Blog Framework/Generator
+
+<!-- more -->
+
+「Two things to tell you」, first, compared with Hexo, Valaxy is superior in both development experience and speed, second, compared with VitePress/VuePress, Valaxy has more integration features for blogs, such as article list hook, automatic routing and component registration, overlay layout and theme, etc.
+
+It seems hard to understand the advantages of Valaxy.
+
+I will compare Valaxy with the existing Hexo (popular static blog framework) and vitepress / vuepress (popular static site generator), and explain the advantages of Valaxy.
+:::
 
 ```ts
 import type { UserConfig } from 'valaxy'
@@ -47,9 +67,17 @@ const config: UserConfig<ThemeUserConfig> = {
 export default config
 ```
 
+:::zh-CN
 配置、文章热更新
 
 而不是像 hexo 一样重新加载页面
+:::
+
+:::en
+Hot update for configuration, article 
+
+Instead of reloading pages like hexo
+:::
 
 ### Motivation
 
@@ -67,6 +95,7 @@ export default config
 
 - [iles](https://github.com/ElMassimo/iles)
 
+:::zh-CN
 在完成了 Valaxy 基础结构的开发后，我从群友处得知了 iles，这和我实现的许多功能十分相似。
 
 它相比 Vitepress 拥有更多功能，也很适合写一个拥有更多交互的文档。
@@ -74,3 +103,14 @@ export default config
 不过它的定位仍旧是静态站点生成器，这与 Valaxy 静态博客生成器的定位不同。
 
 因为 Valaxy 除此之外，还会提供文章列表、分页、标签、分类等更多面向博客的功能，并支持扩展与自定义博客主题。
+:::
+
+:::en
+After completing the development of Valaxy's basic structures, I learned about iles from my group friend, which is very similar to many features I have archieved.
+
+It has more features than Vitepress and is also suitable for writing a document with more interaction.
+
+However, its positioning is still static site generator, which is different from that of Valaxy static blog generator.
+
+In addition, Valaxy also provides more blog oriented features such as article list, pagination, tag and category, and supports extension and customization of blog topics.
+:::

--- a/demo/yun/pages/posts/index.md
+++ b/demo/yun/pages/posts/index.md
@@ -3,7 +3,16 @@ title: 博文
 date: 2022-04-09
 ---
 
+:::zh-CN
 我会写些 Valaxy 的开发笔记和使用说明。
 
 - [Valaxy 设计原则](/posts/design)
 - [Valaxy 开发笔记](/posts/dev)
+:::
+
+:::en
+I will write some development notes and instructions of Valaxy.
+
+- [Design principles of Valaxy](/posts/design)
+- [Development notes of Valaxy](/posts/dev)
+:::

--- a/demo/yun/pages/posts/toc.md
+++ b/demo/yun/pages/posts/toc.md
@@ -11,6 +11,7 @@ tags:
   - test
 ---
 
+:::zh-CN
 [[toc]]
 
 标题是一级标题
@@ -39,3 +40,35 @@ tags:
 
 - [ ] FLAG
 - [x] FLAG
+:::
+
+:::en
+[[toc]]
+
+The title is a primary title
+
+## Secondary title
+
+### Tertiary title
+
+#### Level four title
+
+##### Level five title
+
+###### Level six title
+
+## Title
+
+## List title
+
+- AAA
+- BBB
+- CCC
+  - DDD
+    - EEE
+
+### Checkbox
+
+- [ ] FLAG
+- [x] FLAG
+:::

--- a/packages/valaxy/src/client/locales/zh-CN.yml
+++ b/packages/valaxy/src/client/locales/zh-CN.yml
@@ -59,7 +59,7 @@ footer:
   total_visitors: 总访客量
 
 counter:
-  archives: 暂无日志 | 共计 1 篇日志 | 共计 {count} 篇日志
+  archives: 暂无日志 | 共计 {count} 篇日志
   categories: 暂无分类 | 共计 {count} 个分类
   tags: 暂无标签 | 共计 {count} 个标签
   albums:


### PR DESCRIPTION
1. Delete redundant complex number content in Chinese
2. Translate the articles in `demo/yun/pages/posts/` into English

And here is a question.
How can I make titles of articles internationalized?