### PR TITLE
fix: tsconfig include path for create-valaxy

### DIFF
--- a/packages/create-valaxy/template/tsconfig.json
+++ b/packages/create-valaxy/template/tsconfig.json
@@ -5,5 +5,6 @@
       "@/*": ["demo/yun/*"]
     }
   },
+  "include": ["layouts", "conponents"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/24885181/177343957-64979f5c-eb43-4e65-8393-d913d66a8ff5.jpg)

fix this problem by simply putting `layouts` and `conponents` into include path