### PR TITLE
feat(theme-press): beautify the sun-moon switch btn

### DIFF
--- a/packages/valaxy-theme-press/components/nav/PressNavBar.vue
+++ b/packages/valaxy-theme-press/components/nav/PressNavBar.vue
@@ -35,9 +35,13 @@ const themeConfig = useThemeConfig()
 
       <PressToggleLocale m="x-2" />
 
-      <button m="x-2" type="button" aria-label="Toggle Dark Mode" @click="toggleDark()">
-        <div v-if="!isDark" i-ri-sun-line />
-        <div v-else i-ri-moon-line />
+      <button class="switch switchAppearance" type="button" aria-label="Toggle Dark Mode" @click="toggleDark()">
+        <span class="check">
+          <span class="icon-wrap">
+            <div v-if="!isDark" class="icon" i-ri-sun-line />
+            <div v-else class="icon" i-ri-moon-line />
+          </span>
+        </span>
       </button>
     </div>
   </div>
@@ -122,5 +126,60 @@ const themeConfig = useThemeConfig()
 
 .social-links {
   margin-right: -8px;
+}
+
+.switch {
+  position: relative;
+  display: block;
+  box-sizing: border-box;
+  width: 40px;
+  height: 22px;
+  border-radius: 11px;
+  border: 1px solid var(--pr-divider-switch);
+  background-color: var(--pr-bg-switch);
+  transition: border-color 0.25s, background-color 0.25s;
+}
+
+.switch:hover {
+  border-color: #8e8e8e;
+}
+
+.check {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background-color: #ffffff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.06);;
+  transition: background-color 0.25s, transform 0.25s;
+}
+
+.dark .check {
+  background-color: #1a1a1a;
+}
+
+.icon-wrap {
+  box-sizing: border-box;
+  display: block;
+  padding: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+}
+
+.icon {
+  width: 12px;
+  height: 12px;
+  background-color: rgba(60, 60, 60, 0.7);
+}
+
+.dark .icon {
+  background-color: rgba(255, 255, 255, 0.87);
+}
+
+.dark .switchAppearance :deep(.check) {
+  transform: translateX(18px);
 }
 </style>

--- a/packages/valaxy-theme-press/components/nav/PressNavBar.vue
+++ b/packages/valaxy-theme-press/components/nav/PressNavBar.vue
@@ -35,7 +35,7 @@ const themeConfig = useThemeConfig()
       </template>
 
       <PressToggleLocale m="x-2" />
-      <PressSwitchAppearance />
+      <PressSwitchAppearance m="l-2" />
     </div>
   </div>
 </template>

--- a/packages/valaxy-theme-press/components/nav/PressNavBar.vue
+++ b/packages/valaxy-theme-press/components/nav/PressNavBar.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
-import { isDark, toggleDark, useConfig, useSidebar } from 'valaxy'
+import { useConfig, useSidebar } from 'valaxy'
 import { useThemeConfig } from '../../composables'
+import PressSwitchAppearance from './PressSwitchAppearance.vue'
 
 defineProps<{
   isScreenOpen?: boolean
@@ -34,15 +35,7 @@ const themeConfig = useThemeConfig()
       </template>
 
       <PressToggleLocale m="x-2" />
-
-      <button class="switch switchAppearance" type="button" aria-label="Toggle Dark Mode" @click="toggleDark()">
-        <span class="check">
-          <span class="icon-wrap">
-            <div v-if="!isDark" class="icon" i-ri-sun-line />
-            <div v-else class="icon" i-ri-moon-line />
-          </span>
-        </span>
-      </button>
+      <PressSwitchAppearance />
     </div>
   </div>
 </template>
@@ -126,60 +119,5 @@ const themeConfig = useThemeConfig()
 
 .social-links {
   margin-right: -8px;
-}
-
-.switch {
-  position: relative;
-  display: block;
-  box-sizing: border-box;
-  width: 40px;
-  height: 22px;
-  border-radius: 11px;
-  border: 1px solid var(--pr-divider-switch);
-  background-color: var(--pr-bg-switch);
-  transition: border-color 0.25s, background-color 0.25s;
-}
-
-.switch:hover {
-  border-color: #8e8e8e;
-}
-
-.check {
-  position: absolute;
-  top: 1px;
-  left: 1px;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background-color: #ffffff;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.06);;
-  transition: background-color 0.25s, transform 0.25s;
-}
-
-.dark .check {
-  background-color: #1a1a1a;
-}
-
-.icon-wrap {
-  box-sizing: border-box;
-  display: block;
-  padding: 3px;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-}
-
-.icon {
-  width: 12px;
-  height: 12px;
-  background-color: rgba(60, 60, 60, 0.7);
-}
-
-.dark .icon {
-  background-color: rgba(255, 255, 255, 0.87);
-}
-
-.dark .switchAppearance :deep(.check) {
-  transform: translateX(18px);
 }
 </style>

--- a/packages/valaxy-theme-press/components/nav/PressSwitchAppearance.vue
+++ b/packages/valaxy-theme-press/components/nav/PressSwitchAppearance.vue
@@ -21,8 +21,8 @@ import { isDark, toggleDark } from 'valaxy'
   width: 40px;
   height: 22px;
   border-radius: 11px;
-  border: 1px solid var(--pr-divider-switch);
-  background-color: var(--pr-bg-switch);
+  border: 1px solid var(--pr-switch-divider);
+  background-color: var(--pr-switch-bg);
   transition: border-color 0.25s, background-color 0.25s;
 }
 
@@ -38,7 +38,7 @@ import { isDark, toggleDark } from 'valaxy'
   height: 18px;
   border-radius: 50%;
   background-color: #ffffff;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.06);;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.06);
   transition: background-color 0.25s, transform 0.25s;
 }
 

--- a/packages/valaxy-theme-press/components/nav/PressSwitchAppearance.vue
+++ b/packages/valaxy-theme-press/components/nav/PressSwitchAppearance.vue
@@ -3,7 +3,7 @@ import { isDark, toggleDark } from 'valaxy'
 </script>
 
 <template>
-  <button class="switch switchAppearance" type="button" aria-label="Toggle Dark Mode" @click="toggleDark()">
+  <button class="switch switch-appearance" type="button" aria-label="Toggle Dark Mode" @click="toggleDark()">
     <span class="check">
       <span class="icon-wrap">
         <div v-if="!isDark" class="icon" i-ri-sun-line />
@@ -65,7 +65,7 @@ import { isDark, toggleDark } from 'valaxy'
   background-color: rgba(255, 255, 255, 0.87);
 }
 
-.dark .switchAppearance :deep(.check) {
+.dark .switch-appearance :deep(.check) {
   transform: translateX(18px);
 }
 </style>

--- a/packages/valaxy-theme-press/components/nav/PressSwitchAppearance.vue
+++ b/packages/valaxy-theme-press/components/nav/PressSwitchAppearance.vue
@@ -1,0 +1,71 @@
+<script lang="ts" setup>
+import { isDark, toggleDark } from 'valaxy'
+</script>
+
+<template>
+  <button class="switch switchAppearance" type="button" aria-label="Toggle Dark Mode" @click="toggleDark()">
+    <span class="check">
+      <span class="icon-wrap">
+        <div v-if="!isDark" class="icon" i-ri-sun-line />
+        <div v-else class="icon" i-ri-moon-line />
+      </span>
+    </span>
+  </button>
+</template>
+
+<style lang="scss" scoped>
+.switch {
+  position: relative;
+  display: block;
+  box-sizing: border-box;
+  width: 40px;
+  height: 22px;
+  border-radius: 11px;
+  border: 1px solid var(--pr-divider-switch);
+  background-color: var(--pr-bg-switch);
+  transition: border-color 0.25s, background-color 0.25s;
+}
+
+.switch:hover {
+  border-color: #8e8e8e;
+}
+
+.check {
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background-color: #ffffff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.06);;
+  transition: background-color 0.25s, transform 0.25s;
+}
+
+.dark .check {
+  background-color: #1a1a1a;
+}
+
+.icon-wrap {
+  box-sizing: border-box;
+  display: block;
+  padding: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+}
+
+.icon {
+  width: 12px;
+  height: 12px;
+  background-color: rgba(60, 60, 60, 0.7);
+}
+
+.dark .icon {
+  background-color: rgba(255, 255, 255, 0.87);
+}
+
+.dark .switchAppearance :deep(.check) {
+  transform: translateX(18px);
+}
+</style>

--- a/packages/valaxy-theme-press/styles/css-vars.scss
+++ b/packages/valaxy-theme-press/styles/css-vars.scss
@@ -1,4 +1,5 @@
 :root {
+  // aside
   --pr-aside-text-1: #213547;
   --pr-aside-text-2: #3c3c3cb3;
 
@@ -17,16 +18,18 @@
   --pr-z-index-backdrop: 10;
   --pr-z-index-sidebar: 11;
 
-  --pr-divider-switch: rgba(60, 60, 60, 0.29);
-  --pr-bg-switch: #f1f1f1;
+  // switch
+  --pr-switch-divider: rgba(60, 60, 60, 0.29);
+  --pr-switch-bg: #f1f1f1;
 }
 
 .dark {
+  // aside
   --pr-aside-text-1: #ffffffde;
   --pr-aside-text-2: #ebebeb99;
-
   --pr-aside-divider: rgba(84, 84, 84, 0.48);
 
-  --pr-divider-switch: rgba(84, 84, 84, 0.65);
-  --pr-bg-switch: #3a3a3a;
+  // switch
+  --pr-switch-divider: rgba(84, 84, 84, 0.65);
+  --pr-switch-bg: #3a3a3a;
 }

--- a/packages/valaxy-theme-press/styles/css-vars.scss
+++ b/packages/valaxy-theme-press/styles/css-vars.scss
@@ -16,6 +16,9 @@
   --pr-z-index-local-nav: 9;
   --pr-z-index-backdrop: 10;
   --pr-z-index-sidebar: 11;
+
+  --pr-divider-switch: rgba(60, 60, 60, 0.29);
+  --pr-bg-switch: #f1f1f1;
 }
 
 .dark {
@@ -23,4 +26,7 @@
   --pr-aside-text-2: #ebebeb99;
 
   --pr-aside-divider: rgba(84, 84, 84, 0.48);
+
+  --pr-divider-switch: rgba(84, 84, 84, 0.65);
+  --pr-bg-switch: #3a3a3a;
 }


### PR DESCRIPTION
Modify the style of the dark mode switch, from single button to sliding switch.