### PR TITLE
feat: add valaxy-addon-meting package

### DIFF
--- a/packages/valaxy-addon-meting/App.vue
+++ b/packages/valaxy-addon-meting/App.vue
@@ -1,0 +1,22 @@
+<script lang="ts" setup>
+import { useAplayer } from 'valaxy'
+import { computed } from 'vue'
+const props = defineProps<{
+  [key: string]: any
+}>()
+
+const loadAplayer = computed(() => props.auto || props.url || (props.id && props.server && props.type))
+
+if (loadAplayer.value)
+  useAplayer()
+</script>
+
+<template>
+  <meting-js
+    v-if="loadAplayer"
+    v-bind="props"
+    :fixed="true"
+  />
+</template>
+
+<style lang="scss" scoped></style>

--- a/packages/valaxy-addon-meting/README.md
+++ b/packages/valaxy-addon-meting/README.md
@@ -1,0 +1,20 @@
+# valaxy-addon-meting
+
+Global meting music player
+
+```ts
+import { defineConfig } from 'valaxy'
+export default defineConfig({
+  addons: [
+    ['valaxy-addon-meting', {
+      props: {
+        /** @see https://github.com/metowolf/MetingJS */
+      }
+    }]
+  ]
+})
+```
+
+## props
+
+you can [meting#options](https://github.com/metowolf/MetingJS#option)

--- a/packages/valaxy-addon-meting/package.json
+++ b/packages/valaxy-addon-meting/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "valaxy-addon-meting",
+  "global": true,
+  "version": "0.0.1",
+  "license": "MIT",
+  "keywords": [
+    "valaxy",
+    "addon"
+  ],
+  "dependencies": {}
+}


### PR DESCRIPTION
# valaxy-addon-meting

Global meting music player

```ts
import { defineConfig } from 'valaxy'
export default defineConfig({
  addons: [
    ['valaxy-addon-meting', {
      props: {
        /** @see https://github.com/metowolf/MetingJS */
      }
    }]
  ]
})
```

## props

you can [meting#options](https://github.com/metowolf/MetingJS#option)