### PR TITLE
chore: set vitest globals to true

### DIFF
--- a/test/addon.test.ts
+++ b/test/addon.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from 'vitest'
 import { getAddonRoot, parseAddonLike, parseAddonOptions, readAddonModule } from '../packages/valaxy/node/utils/addons'
 
 describe('addon parse', () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,3 @@
-import { describe, expect, it } from 'vitest'
-
 // todo merge config test
 describe('merge config', async () => {
   it('config:merge:theme', () => {

--- a/test/md.test.ts
+++ b/test/md.test.ts
@@ -1,6 +1,5 @@
 // import { resolve } from 'path'
 // import fs from 'fs'
-import { describe, expect, it } from 'vitest'
 import { createMarkdownRenderer } from '../packages/valaxy/node/markdown'
 
 // const mdDir = resolve(__dirname, 'fixtures/markdown')

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,4 @@
 import { resolve } from 'path'
-import { describe, expect, it } from 'vitest'
 import { getIndexHtml } from '../packages/valaxy/node'
 import type { DefaultThemeConfig, ResolvedValaxyOptions, ValaxyConfig } from '../packages/valaxy'
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 import { getIndexHtml } from '../packages/valaxy/node'
-import type { DefaultThemeConfig, ResolvedValaxyOptions, ValaxyConfig } from '../packages/valaxy'
+import type { DefaultThemeConfig, ResolvedValaxyOptions, SiteConfig, ValaxyConfig } from '../packages/valaxy'
 
 const clientRoot = resolve(__dirname, '../packages/valaxy/client')
 const themeRoot = resolve(__dirname, 'fixtures/theme')
@@ -28,7 +28,7 @@ describe('utils', () => {
   it('mode light', async () => {
     const config = {
       mode: 'auto',
-    } as ValaxyConfig<ValaxyThemeConfig>
+    } as ValaxyConfig<SiteConfig>
     const indexHtml = await getIndexHtml({ clientRoot, themeRoot, userRoot, config } as ResolvedValaxyOptions)
 
     const head = indexHtml.match(/<head>([\s\S]*?)<\/head>/im)?.[1]

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path'
+import type { DefaultThemeConfig, SiteConfig } from 'valaxy/types'
+import type { ResolvedValaxyOptions, ValaxyConfig } from 'valaxy/node'
 import { getIndexHtml } from '../packages/valaxy/node'
-import type { DefaultThemeConfig, ResolvedValaxyOptions, SiteConfig, ValaxyConfig } from '../packages/valaxy'
 
 const clientRoot = resolve(__dirname, '../packages/valaxy/client')
 const themeRoot = resolve(__dirname, 'fixtures/theme')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
     "types": [
-      "vitest",
+      "vitest/globals",
       "vite/client",
       "vue/ref-macros",
       "vite-plugin-pages/client",
@@ -33,6 +33,7 @@
   },
   "include": [
     "./*.ts",
+    "./test/*.ts",
     "./packages/**/*.ts",
     "./packages/**/*.vue"
   ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
+    globals: true,
     deps: {
       inline: ['@vue', '@vueuse', 'vue-demi'],
     },


### PR DESCRIPTION
Signed-off-by: Sepush <sepush@outlook.com>

set `globals: true ` like jest so that we don't need to import in every test files