### PR TITLE
fix: auto wrap for tags page, close #114

### DIFF
--- a/packages/valaxy-theme-press/styles/css-vars.scss
+++ b/packages/valaxy-theme-press/styles/css-vars.scss
@@ -21,8 +21,8 @@
 
   // z-index
   --va-z-overlay: var(--pr-z-index-backdrop);
-  --pr-z-index-nav: 8;
-  --pr-z-index-local-nav: 9;
+  --pr-z-index-local-nav: 8;
+  --pr-z-index-nav: 9;
   --pr-z-index-backdrop: 10;
   --pr-z-index-sidebar: 11;
 

--- a/packages/valaxy-theme-yun/layouts/tags.vue
+++ b/packages/valaxy-theme-yun/layouts/tags.vue
@@ -62,7 +62,7 @@ const title = usePostTitle(frontmatter)
         {{ t('counter.tags', Array.from(tags).length) }}
       </div>
 
-      <div text="center">
+      <div text="center" class="break-words">
         <span v-for="[key, tag] in Array.from(tags).sort()" :key="key" class="post-tag cursor-pointer" :style="getTagStyle(tag.count)" p="1" @click="displayTag(key.toString())">
           #{{ key }}<span text="xs">[{{ tag.count }}]</span>
         </span>


### PR DESCRIPTION
1. Do not wrap when overflowing ( theme yun )
Before:
![Before](https://user-images.githubusercontent.com/54099603/188266870-3a4e28f5-740c-4ac3-b92e-92fdfaea7e8b.png)
After adding .break-words (overflow-wrap: break-word;):
![After](https://user-images.githubusercontent.com/54099603/188266875-4089dcd2-9cfe-4ba0-a769-e949d7d34cac.png)

2. nav was covered with local-nav ( #114 ) ( theme press )
3. ~~Incorrect style of `PressAside.vue` ( #84 ) ( theme press )~~
