### PR TITLE
Code tags have back quotes

### DIFF
--- a/packages/valaxy-theme-press/styles/markdown.scss
+++ b/packages/valaxy-theme-press/styles/markdown.scss
@@ -29,6 +29,14 @@
     padding: 3px 6px;
     border-radius: 4px;
     font-weight: 500;
+
+    &::before {
+      content: none;
+    }
+
+    &::after {
+      content: none;
+    }
   }
 }
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/54099603/202847300-5235aaad-6f94-4402-821a-3c9770ebc536.png)
After:
![image](https://user-images.githubusercontent.com/54099603/202847288-e732849f-d281-42de-b9e8-5156e0e9f604.png)
