### PR TITLE
fix: fault of addon and resolve config

### DIFF
--- a/packages/valaxy/node/config/index.ts
+++ b/packages/valaxy/node/config/index.ts
@@ -1,7 +1,7 @@
 import type { VitePluginConfig as UnoCssConfig } from 'unocss/vite'
 import type { Awaitable } from '@antfu/utils'
 import type { SiteConfig, UserSiteConfig } from '../../types'
-import type { UserValaxyNodeConfig, ValaxyNodeConfig } from '../types'
+import type { UserValaxyNodeConfig, ValaxyExtendConfig, ValaxyNodeConfig } from '../types'
 
 export * from './addon'
 
@@ -21,6 +21,13 @@ export function defineValaxyConfig<ThemeConfig>(config: UserValaxyNodeConfig<The
   return config
 }
 export const defineConfig = defineValaxyConfig
+
+/**
+ * Type helper for addon/valaxy.config.ts
+ */
+export function defineValaxyExtendConfig(config: ValaxyExtendConfig) {
+  return config
+}
 
 export const defaultSiteConfig: SiteConfig = {
   mode: 'auto',

--- a/packages/valaxy/node/utils/config.ts
+++ b/packages/valaxy/node/utils/config.ts
@@ -66,7 +66,7 @@ export async function resolveValaxyConfig(options: ValaxyEntryOptions) {
 export async function resolveAddonConfig(addons: ValaxyAddonResolver[], options?: ResolvedValaxyOptions) {
   let valaxyConfig: ValaxyNodeConfig = {} as ValaxyNodeConfig
   for (const addon of addons) {
-    const { config, configFile } = await loadConfigFromFile<ValaxyNodeConfig>('index', {
+    const { config, configFile } = await loadConfigFromFile<ValaxyNodeConfig>('valaxy.config', {
       rewrite<F = ValaxyNodeConfig | ValaxyAddonFn>(obj: F, _filepath: string) {
         return (typeof obj === 'function' ? obj(addon, options!) : obj)
       },


### PR DESCRIPTION
修复 addon valaxy config 断层 #171

- 提供 `defineValaxyExtendConfig` 给 `addon` 使用，不包含 `theme` 类参数
- 将 `resolveAddonConfig` 解析的配置地址更改为 `addon/valaxy.config`