### PR TITLE
docs(deploy.md): requested URL returned error: 403

### DIFF
--- a/docs/pages/guide/deploy.md
+++ b/docs/pages/guide/deploy.md
@@ -25,6 +25,8 @@ npm run build
 
 上传至 GitHub Repo，打开 `Settings` -> `Pages`，选择 `gh-pages` 分支。
 
+选择 Github Repo，打开 `Settings`-> `Action` -> `General` -> `Workflow permissions`，选择 `read and write permissions`。 
+
 > `gh-pages` 已由 `.github/workflows/gh-pages.yml` 自动部署。
 
 #### Netlify


### PR DESCRIPTION
使用 Github Action 自动部署工作流，不设置 docs 中描述的配置，可能会出现如下错误。
> 我不确定现在的仓库是否会自动设置权限
![image](https://user-images.githubusercontent.com/62499904/218617640-fc2abfe0-febc-4eea-828f-a0b051b6d454.png)

配置仓库权限后，部署成功，如下图。
![image](https://user-images.githubusercontent.com/62499904/218617837-126b2042-65b5-42fb-ab2f-c950687dd0d8.png)
