### PR TITLE
docs(faq.md): Tag text in the article list is broken up

### DIFF
--- a/docs/pages/dev/faq.md
+++ b/docs/pages/dev/faq.md
@@ -24,3 +24,11 @@ pnpm test:space
 > [The Fixed Background Attachment Hack | CSS Tricks](https://css-tricks.com/the-fixed-background-attachment-hack/)
 
 改为使用 `::before` 伪元素实现。
+
+## 文章列表中的标签文字被分解
+
+将文章标签 `tags` 如下格式：
+```bash
+tags: 
+    - 我的标签
+```


### PR DESCRIPTION
从 `hexo` 迁移到 `valaxy` 后，文章列表中的标签出现如下图的情况。

假如修改 `tags` 格式后，这篇文章回退到一开始出现 `标签文字被分解` 的现场，也无法复现，标签格式仍然为正常的。

> 图片来自 QQ 群

![image](https://user-images.githubusercontent.com/62499904/218622394-2e612b82-834e-47e9-a08e-099b7d6de8a9.png)

按照提交 `docs` 的描述修改后，如下图。
![image](https://user-images.githubusercontent.com/62499904/218622252-1f6d9874-004f-4207-a0ec-b78dd14e7a89.png)
