### PR TITLE
docs: improve the gallery page

### DIFF
--- a/docs/components/ThemeGallery.vue
+++ b/docs/components/ThemeGallery.vue
@@ -1,20 +1,81 @@
 <script lang="ts" setup>
-defineProps<{
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const props = withDefaults(defineProps<{
   themes: {
     name: string
     repo: string
     desc: string
+    siteImage: string
+    siteExampleURL?: string
     tags?: string[]
   }[]
-}>()
+}>(), {})
+
+const { t } = useI18n()
+const keyword = ref('')
+const filteredThemes = computed(() => {
+  return props.themes.filter((item) => {
+    return item.name.includes(keyword.value) || item.tags?.some(t => t.includes(keyword.value))
+  })
+})
 </script>
 
 <template>
-  <ul>
-    <li v-for="theme, i in themes" :key="i">
-      <a :href="`https://github.com/${theme.repo}`" target="_blank">
-        {{ theme.name }}
-      </a>: {{ theme.desc }}
+  <div class="search-wrapper relative mx-0.5 my-4">
+    <div class="i-ri-search-line absolute text-slate-400 absolute inset-y-0 top-50%  -translate-y-2/4 pl-8 " />
+    <input
+      v-model="keyword" :placeholder="t('gallery.tip')"
+      class="placeholder:text-slate-400
+      focus:outline-none focus:border-sky-500 focus:ring-sky-500 focus:ring-1
+      border border-slate-300
+      pl-8 pr-3 b-3 pl-4 w-full h-16"
+      type="text" name="search"
+    >
+  </div>
+  <ul class="m-0 p-0 sm:grid-cols-1 lg:grid-cols-2 grid">
+    <li v-for="theme, i in filteredThemes" :key="i" class="w-full lg:p-4 sm:pb-4 list-none">
+      <div class="img-wrapper" cursor-pointer>
+        <img :src="theme.siteImage" :alt="theme.name">
+        <a target="_blank" :href="theme.siteExampleURL || theme.repo" :alt="theme.name" class="mask">
+          <div class="i-ri-eye-line text-40px text-white " />
+        </a>
+      </div>
+      <a :href="theme.repo" target="_blank">
+        <h3> {{ theme.name }}</h3>
+      </a>
+      <p>{{ theme.desc }}</p>
+      <ul class=" m-0 p-0 flex flex-wrap">
+        <span v-for="tag, j in theme.tags" :key="j" class="break-all text-gray mr-6px">
+          #{{ tag }}
+        </span>
+      </ul>
     </li>
   </ul>
 </template>
+
+<style scoped lang="scss">
+.img-wrapper {
+  position: relative;
+  overflow: hidden;
+  &:hover {
+    .mask {
+      transform: translateY(0%);
+    }
+  }
+  .mask {
+    transform: translateY(-100%);
+    transition: transform 0.5s ease-out;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba($color: #000000, $alpha: 0.6);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}
+</style>

--- a/docs/locales/en.yml
+++ b/docs/locales/en.yml
@@ -1,0 +1,2 @@
+gallery:
+  tip: search

--- a/docs/locales/zh-CN.yml
+++ b/docs/locales/zh-CN.yml
@@ -1,0 +1,2 @@
+gallery:
+  tip: 搜索

--- a/docs/pages/guide/deploy.md
+++ b/docs/pages/guide/deploy.md
@@ -48,23 +48,31 @@ npm run build
 ::: zh-CN
 在使用 `pnpm create valaxy` 创建模版项目时，已内置文件[`.github/workflows/gh-pages.yml`](https://github.com/YunYouJun/valaxy/blob/main/packages/create-valaxy/template/.github/workflows/gh-pages.yml) 以实现 GitHub Actions 的自动部署工作流。
 
-上传至 GitHub Repo，打开 `Settings` -> `Pages`，选择 `gh-pages` 分支。
 
 选择 Github Repo，打开 `Settings`-> `Action` -> `General` -> `Workflow permissions`，选择 `read and write permissions`。
 
+上传至 GitHub Repo，打开 `Settings` -> `Pages`，选择 `gh-pages` 分支。
+
 > `gh-pages` 已由 `.github/workflows/gh-pages.yml` 自动部署。
-:::
+
 
 > 注意修改 `gh-pages.yml` 中的 `on.push.branches` 为你源代码所在的分支，默认为 `main`。
+
+:::
+
 
 ::: en
 When you use `pnpm create valaxy` to create a template project, it contains the file [`.github/workflows/gh-pages.yml`](https://github.com/YunYouJun/valaxy/blob/main/packages/create-valaxy/template/.github/workflows/gh-pages.yml) for the CI workflow of GitHub Actions.
 
-Push to your GitHub repository, and go to `Settings` -> `Pages`. Select `gh-pages` branch.
 
 Select the Github repository, go to `Settings`-> `Action` -> `General` -> `Workflow permissions`, and select `read and write permissions`。
 
+Push to your GitHub repository, and go to `Settings` -> `Pages`. Select `gh-pages` branch.
+
 > `gh-pages` has been automatically deployed by `.github/workflows/gh-pages.yml`.
+
+> Please note that the 'on.push.branches' in' gh-pages.yml' should be modified to the branch where your source code is located, and the default is 'main'.
+
 :::
 
 #### Netlify

--- a/docs/pages/themes/gallery.md
+++ b/docs/pages/themes/gallery.md
@@ -7,39 +7,39 @@ end: false
 
 themes:
   - name: valaxy-theme-yun
-    repo: YunYouJun/valaxy/tree/main/packages/valaxy-theme-yun
-    desc: Default Theme for Valaxy
-    # todo
-    # preview:
+    repo: https://github.com/YunYouJun/valaxy/tree/main/packages/valaxy-theme-yun
+    desc: Default Theme for Valaxy Default Theme for Valaxy Default Theme for Valaxy Default Theme for Valaxy Default Theme for Valaxy
+    siteImage: https://s2.loli.net/2023/05/05/QoK4ZimqN3fgRdD.png
+    siteExampleURL:  https://www.yunyoujun.cn
     tags:
       - yun
       - light
-
   - name: valaxy-theme-press
-    repo: YunYouJun/valaxy/tree/main/packages/valaxy-theme-press
+    repo: https://github.com/YunYouJun/valaxy/tree/main/packages/valaxy-theme-press
     desc: Docs Theme for Valaxy
-    # todo
-    # preview:
+    siteImage: https://s2.loli.net/2023/05/05/1DyEudpohIl47cP.png
     tags:
       - docs
       - press
 ---
-
+::: zh-CN
 ::: tip
 
 很高兴你看到这里，这里是 Valaxy 主题橱窗，我将会为提交主题（符合基础使用质量）的前五位作者赠送[「小云立牌」](https://twitter.com/YunYouJun/status/1633116052174299137) :P。
 
-:::
 
-::: zh-CN
+
 欢迎 [提交主题](https://github.com/YunYouJun/valaxy/blob/main/docs/pages/themes/gallery.md)。
 :::
 
+
 ::: en
+::: tip
+Nice to see you here. This is the Valaxy Themes Gallery, and I will give away [「小云立牌」](https://twitter.com/YunYouJun/status/1633116052174299137) to the top five authors who submitted the theme (meeting the basic usage quality) :P.
+
 Feel free to [submit your theme](https://github.com/YunYouJun/valaxy/blob/main/docs/pages/themes/gallery.md).
 :::
 
-> 后续将会优化橱窗展示。
 
 <ThemeGallery :themes="frontmatter.themes" />
 <br />


### PR DESCRIPTION
完成 文档的 gallery 页面展示


ps：为什么 我在本地仓库同步上游分支并且merge后， 就多了两个 commit

Merge remote-tracking branch 'upstream/main'
chore: fix deploy about github page (#221)

实际只有最新的 commit，改变了 4 个文件。



