### PR TITLE
feat: image lazyload in posts

### DIFF
--- a/demo/yun/pages/posts/lots-of-images.md
+++ b/demo/yun/pages/posts/lots-of-images.md
@@ -1,0 +1,31 @@
+---
+title: Valaxy 图片懒加载测试
+date: 2023-09-09
+---
+![](https://cdn.yunyoujun.cn/img/bg/girl-in-watertank.webp)
+
+![](https://cdn.yunyoujun.cn/img/bg/stars-timing-0-blur-30px.jpg)
+
+![](https://cdn.yunyoujun.cn/img/bg/galaxy.jpg)
+
+![](https://cdn.yunyoujun.cn/img/bg/mountain-blur-30px.jpg)
+
+![](https://cdn.yunyoujun.cn/img/bg/astronaut.webp)
+
+![](https://cdn.yunyoujun.cn/img/bg/stars-timing-1.jpg)
+
+![](https://cdn.yunyoujun.cn/img/bg/stars-timing-2.jpg)
+
+![](https://cdn.yunyoujun.cn/img/bg/stars-timing-3.jpg)
+
+![](https://cdn.yunyoujun.cn/img/bg/stars-timing-4.jpg)
+
+![](https://cdn.yunyoujun.cn/img/bg/stars-timing-5.jpg)
+
+![](https://cdn.yunyoujun.cn/img/bg/mountain.jpg)
+
+![](https://cdn.yunyoujun.cn/img/meme/bow-to-good-society.jpg)
+
+![](https://cdn.yunyoujun.cn/img/meme/no-bug.gif)
+
+![](https://cdn.yunyoujun.cn/img/meme/no-work.jpg)

--- a/packages/valaxy/client/styles/third/lazyload.scss
+++ b/packages/valaxy/client/styles/third/lazyload.scss
@@ -1,0 +1,4 @@
+img {
+    max-width: 100%;
+    height: auto;
+}

--- a/packages/valaxy/node/markdown/index.ts
+++ b/packages/valaxy/node/markdown/index.ts
@@ -4,6 +4,7 @@ import anchorPlugin from 'markdown-it-anchor'
 import attrsPlugin from 'markdown-it-attrs'
 import emojiPlugin from 'markdown-it-emoji'
 import TaskLists from 'markdown-it-task-lists'
+import lazy_loading from 'markdown-it-image-lazy-loading'
 
 import { componentPlugin } from '@mdit-vue/plugin-component'
 import {
@@ -85,6 +86,8 @@ export async function setupMarkdownPlugins(
       ...mdOptions.anchor,
     })
   }
+
+  md.use(lazy_loading /* mdOptions.lazyload?.options */)
 
   // mdit-vue plugins
   md.use(componentPlugin)

--- a/packages/valaxy/node/markdown/plugins/markdown-it/lazyload.ts
+++ b/packages/valaxy/node/markdown/plugins/markdown-it/lazyload.ts
@@ -1,0 +1,5 @@
+export interface lazyloadOptions {
+  decoding?: boolean
+  base_path?: string
+  image_size?: boolean
+}

--- a/packages/valaxy/node/markdown/types.ts
+++ b/packages/valaxy/node/markdown/types.ts
@@ -14,6 +14,8 @@ import {
 import { type SfcPluginOptions } from '@mdit-vue/plugin-sfc'
 import { type TocPluginOptions } from '@mdit-vue/plugin-toc'
 
+// import type { lazyloadOptions } from './plugins/markdown-it/lazyload'
+
 import { type Blocks } from './plugins/markdown-it/container'
 
 export type ThemeOptions =
@@ -55,4 +57,8 @@ export interface MarkdownOptions {
   blocks?: Blocks
 
   externalLinks?: Record<string, string>
+  /* lazyload?: {
+    enabled?: boolean
+    options: lazyloadOptions
+  } */
 }

--- a/packages/valaxy/node/shims.d.ts
+++ b/packages/valaxy/node/shims.d.ts
@@ -16,3 +16,8 @@ declare module 'markdown-it-task-lists' {
 declare module 'diacritics' {
   export const remove: (str: string) => string
 }
+
+declare module 'markdown-it-image-lazy-loading' {
+  const def: any
+  export default def
+}

--- a/packages/valaxy/package.json
+++ b/packages/valaxy/package.json
@@ -93,6 +93,7 @@
     "markdown-it-attrs": "^4.1.6",
     "markdown-it-container": "^3.0.0",
     "markdown-it-emoji": "^2.0.2",
+    "markdown-it-image-lazy-loading": "^1.2.0",
     "markdown-it-table-of-contents": "^0.6.0",
     "markdown-it-task-lists": "^2.1.1",
     "medium-zoom": "^1.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
       markdown-it-emoji:
         specifier: ^2.0.2
         version: 2.0.2
+      markdown-it-image-lazy-loading:
+        specifier: ^1.2.0
+        version: 1.2.0
       markdown-it-table-of-contents:
         specifier: ^0.6.0
         version: 0.6.0
@@ -5024,7 +5027,7 @@ packages:
   /eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       is-core-module: 2.13.0
       resolve: 1.22.4
     transitivePeerDependencies:
@@ -5053,7 +5056,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 6.5.0(eslint@8.48.0)(typescript@5.2.2)
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       eslint: 8.48.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -5113,7 +5116,7 @@ packages:
     peerDependencies:
       eslint: ^7.2.0 || ^8
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7(supports-color@5.5.0)
       doctrine: 2.1.0
       eslint: 8.48.0
       eslint-import-resolver-node: 0.3.9
@@ -6201,6 +6204,14 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
+  /image-size@1.0.2:
+    resolution: {integrity: sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    dependencies:
+      queue: 6.0.2
+    dev: false
+
   /immutable@4.3.2:
     resolution: {integrity: sha512-oGXzbEDem9OOpDWZu88jGiYCvIsLHMvGw+8OXlpsvTFvIQplQbjg1B1cvKg8f7Hoch6+NGjpPsH1Fr+Mc2D1aA==}
 
@@ -6236,7 +6247,6 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
 
   /ini@2.0.0:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
@@ -6997,6 +7007,12 @@ packages:
 
   /markdown-it-emoji@2.0.2:
     resolution: {integrity: sha512-zLftSaNrKuYl0kR5zm4gxXjHaOI3FAOEaloKmRA5hijmJZvSjmxcokOLlzycb/HXlUFWzXqpIEoyEMCE4i9MvQ==}
+    dev: false
+
+  /markdown-it-image-lazy-loading@1.2.0:
+    resolution: {integrity: sha512-/aeNoa7DxCe3Ey01sF68shdj5JML+ixzr0adWAliwJZp0lpezl84iLCWybhcmCmSZgX0RcO7wGKzXMOI57RbKQ==}
+    dependencies:
+      image-size: 1.0.2
     dev: false
 
   /markdown-it-table-of-contents@0.6.0:
@@ -7797,6 +7813,12 @@ packages:
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  /queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
+    dependencies:
+      inherits: 2.0.4
+    dev: false
 
   /randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR provides image lazyload by adding `loading="lazy"` attitube to all `<img></img>` elements in posts based on [`markdown-it-image-lazy-loading`](https://github.com/ruanyf/markdown-it-image-lazy-loading). But because of my poor development experience, it cannot be disabled, and you may experience some bug.

Not completely worked, yet. But I can only do this now. 

### Linked Issues

#256
### Additional context

The effect of `loading="lazy"` is not clear on my computer, so I prefer `vanilla-lazyload`. I hope you can code for it this weekend.