### PR TITLE
Add the content of AI summary to the i18n configuration file, and include a typing effect

### DIFF
--- a/packages/valaxy-theme-yun/components/YunAiExcerpt.vue
+++ b/packages/valaxy-theme-yun/components/YunAiExcerpt.vue
@@ -1,13 +1,38 @@
 <script lang="ts" setup>
 import { useFrontmatter } from 'valaxy'
 import { useI18n } from 'vue-i18n'
+import { ref, onMounted } from 'vue'
 
 const fm = useFrontmatter()
 const { t } = useI18n()
+
+const content = ref('')
+let timer: NodeJS.Timeout
+const typing = (interval = 80) => {
+  let i = 0
+  timer = setInterval(() => {
+    content.value += fm.value?.excerpt?.charAt(i)
+    i++
+    if (i === fm.value?.excerpt?.length) {
+      clearInterval(timer)
+    }
+  }, interval)
+  return timer
+}
+
+const clear = () => {
+  clearInterval(timer)
+  content.value = fm.value?.excerpt ?? ''
+}
+
+onMounted(() => {
+  typing()
+})
+
 </script>
 
 <template>
-  <div class="ai-generated-excerpt rounded-lg bg-$va-c-bg-alt p-4">
+  <div @click="clear" class="ai-generated-excerpt rounded-lg bg-$va-c-bg-alt p-4">
     <div font="black" flex items-center>
       <div mr-1 i-ri-robot-2-line />
       <div>
@@ -15,7 +40,7 @@ const { t } = useI18n()
       </div>
     </div>
     <div op="90" mt-1>
-      {{ fm.excerpt }}
+      {{ content }}
     </div>
   </div>
 </template>

--- a/packages/valaxy-theme-yun/locales/en.yml
+++ b/packages/valaxy-theme-yun/locales/en.yml
@@ -1,1 +1,3 @@
 valaxy_theme_yun: Valaxy Theme Yun
+excerpt:
+  ai: AI Summary

--- a/packages/valaxy-theme-yun/locales/zh-CN.yml
+++ b/packages/valaxy-theme-yun/locales/zh-CN.yml
@@ -1,1 +1,3 @@
 valaxy_theme_yun: Valaxy 主题 云
+excerpt:
+  ai: AI 摘要


### PR DESCRIPTION
### Description

Add the content of AI summary to the i18n configuration file, and include a typing effect that can be displayed immediately upon clicking.

添加AI摘要的i18n配置文件内容，并且添加打字机效果，可点击立即显示。

