### PR TITLE
docs: update guide deploy

### DIFF
--- a/docs/pages/guide/deploy.md
+++ b/docs/pages/guide/deploy.md
@@ -111,7 +111,9 @@ When you use `pnpm create valaxy` to create a template project, it contains the 
 
 - 登录你的 Cloudflare 账号，导航到 “Pages” 页面。
 - 点击 `创建项目`、`连接到 Git`，选择你的 GitHub 或者 GitLab 仓库，并点击 `开始设置`。
-- 选择你的部署分支，将 `构建输出目录` 设置为 `dist` 后添加一个环境变量。
+- 选择你的部署分支。
+- 将 `构建命令` 设置为 `npm run build` 。
+- 将 `构建输出目录` 设置为 `dist` 后添加一个环境变量。
 
 > `NODE_VERSION`: `16` （设置 Node 版本）
 
@@ -121,7 +123,9 @@ When you use `pnpm create valaxy` to create a template project, it contains the 
 ::: en
 - Login to your Cloudflare account and navigate to "Pages" page.
 - Click `Create a project` and `Connect to Git`, then select your GitHub or GitLab repository and click `Begin setup`.
-- Select your Production branch, set `Build output directory` to `dist` and add an environment variable.
+- Select your Production branch.
+- Set `Build output directory` to `npm run build` .
+- Set `Build output directory` to `dist` and add an environment variable.
 
 > `NODE_VERSION`: `16` (Set Node version)
 


### PR DESCRIPTION
部署到cf pages部分的步骤似乎缺少了设置构建命令步骤，可能导致部署时无法构建