### PR TITLE
docs: Chinese version of valaxy's tutorial on markdown.

### DIFF
--- a/docs/pages/guide/markdown.md
+++ b/docs/pages/guide/markdown.md
@@ -17,29 +17,29 @@ end: false
 当然，你仍然可以在 Valaxy 中通过添加 MarkdownIt 插件来实现更多功能。
 :::
 
-## Emoji :tada:
+## Emoji表情支持 :tada:
 
-**Input**
+**输入**
 
 ```
 :tada: :100:
 ```
 
-**Output**
+**输出**
 
 :tada: :100:
 
-A [list of all emojis](https://github.com/markdown-it/markdown-it-emoji/blob/master/lib/data/full.mjs) is available.
+这是一个我们所 [支持的Emoji列表](https://github.com/markdown-it/markdown-it-emoji/blob/master/lib/data/full.mjs) 。
 
-## Table of Contents
+## 目录
 
-**Input**
+**输入**
 
 ```
 [[toc]]
 ```
 
-**Output**
+**输出**
 
 [[toc]]
 
@@ -47,7 +47,7 @@ Rendering of the TOC can be configured using the `markdown.toc` option.
 
 ## 代码行高亮
 
-**Input**
+**输入**
 
 ````
 ```js{4}
@@ -61,7 +61,7 @@ export default {
 ```
 ````
 
-**Output**
+**输出**
 
 ```js{4}
 export default {
@@ -73,68 +73,70 @@ export default {
 }
 ```
 
-**Input**
+**输入**
 
 ````md
 ```ts {1}
-// line-numbers is disabled by default
+// 默认禁用行号显示
 const line2 = 'This is line 2'
 const line3 = 'This is line 3'
 ```
 
 ```ts:line-numbers {1}
-// line-numbers is enabled
+// 启用行号显示
 const line2 = 'This is line 2'
 const line3 = 'This is line 3'
 ```
 
 ```ts:line-numbers=2 {1}
-// line-numbers is enabled and start from 2
+// 行号已启用，并从 2 开始计数
 const line3 = 'This is line 3'
 const line4 = 'This is line 4'
 ```
 ````
 
-**Output**
+**输出**
 
 ```ts {1}
-// line-numbers is disabled by default
+// 默认禁用行号显示
 const line2 = 'This is line 2'
 const line3 = 'This is line 3'
 ```
 
 ```ts:line-numbers {1}
-// line-numbers is enabled
+// 启用行号显示
 const line2 = 'This is line 2'
 const line3 = 'This is line 3'
 ```
 
 ```ts:line-numbers=2 {1}
-// line-numbers is enabled and start from 2
+// 行号已启用，并从 2 开始计数
 const line3 = 'This is line 3'
 const line4 = 'This is line 4'
 ````
 
-## Colored Diffs in Code Blocks
+## 代码块的增减色块标识
 
-Adding the `// [!code --]` or `// [!code ++]` comments on a line will create a diff of that line, while keeping the colors of the codeblock.
+在一行上添加 `// [!code --]` 或者 `// [!code ++]` 注释将创建该行代码的增减标识，同时保持代码块的颜色。
 
-**Input**
+**输入**
+
+请注意，在 `!code`后面只需要一个空格，这里有两个空格以防被渲染。
 
 ````
 ```js
 export default {
   data () {
     return {
-      msg: 'Removed' // [!!code --]
-      msg: 'Added' // [!!code ++]
+      msg: 'Removed' // [!code  --]
+      msg: 'Added' // [!code  ++]
     }
   }
 }
 ```
 ````
 
-**Output**
+**输出**
 
 ```js
 export default {
@@ -147,26 +149,28 @@ export default {
 }
 ```
 
-## Errors and Warnings in Code Blocks
+## 代码块中的错误和警告
 
-Adding the `// [!code warning]` or `// [!code error]` comments on a line will color it accordingly.
+在一行代码后中添加 `// [!code warning]` 或者 `// [!code error]` 注释将会使改行代码呈现指定颜色块。
 
-**Input**
+**输入**
+
+请注意，在 `!code`后面只需要一个空格，这里有两个空格以防被渲染。
 
 ````
 ```js
 export default {
   data () {
     return {
-      msg: 'Error', // [!!code error]
-      msg: 'Warning' // [!!code warning]
+      msg: 'Error', // [!code  error]
+      msg: 'Warning' // [!code  warning]
     }
   }
 }
 ```
 ````
 
-**Output**
+**输出**
 
 ```js
 export default {
@@ -179,36 +183,36 @@ export default {
 }
 ```
 
-## Import Code Snippets
+## 导入代码片段
 
-You can import code snippets from existing files via following syntax:
+您可以通过以下语法从现有文件中导入代码片段：
 
 ```md
 <<< @/filepath
 ```
 
-It also supports [line highlighting](#line-highlighting-in-code-blocks):
+它还支持 [行高亮](#line-highlighting-in-code-blocks):
 
 ```md
 <<< @/filepath{highlightLines}
 ```
 
-**Input**
+**输入**
 
 ```md
 <<< @/snippets/snippet.js{2}
 ```
 
-**Code file**
+**代码文件**
 
 <<< @/snippets/snippet.js
 
-**Output**
+**输出**
 
 <<< @/snippets/snippet.js
 
 ::: tip
-The value of `@` corresponds to the source root. By default it's the blog root, unless `srcDir` is configured. Alternatively, you can also import from relative paths:
+`@` 的值与源根相对应。默认情况下是博客根目录，除非配置了 `srcDir` 。另外，你也可以从相对路径导入：
 
 ```md
 <<< ../snippets/snippet.js
@@ -216,23 +220,23 @@ The value of `@` corresponds to the source root. By default it's the blog root, 
 
 :::
 
-You can also use a [VS Code region](https://code.visualstudio.com/docs/editor/codebasics#_folding) to only include the corresponding part of the code file. You can provide a custom region name after a `#` following the filepath:
+您也可以使用 [VS Code region](https://code.visualstudio.com/docs/editor/codebasics#_folding) 只包含代码文件的相应部分。您可以在文件路径后的 `#` 后提供自定义区域名称：
 
-**Input**
+**输入**
 
 ```md
 <<< @/snippets/snippet-with-region.js#snippet{1}
 ```
 
-**Code file**
+**代码文件**
 
 <<< @/snippets/snippet-with-region.js
 
-**Output**
+**输出**
 
 <<< @/snippets/snippet-with-region.js#snippet{1}
 
-You can also specify the language inside the braces (`{}`) like this:
+您也可以像这样在大括号（`{}`）内指定语言：
 
 ```md
 <<< @/snippets/snippet.cs{c#}
@@ -246,13 +250,13 @@ You can also specify the language inside the braces (`{}`) like this:
 <<< @/snippets/snippet.cs{1,2,4-6 c#:line-numbers}
 ```
 
-This is helpful if source language cannot be inferred from your file extension.
+如果无法从文件扩展名推断源语言，这将很有帮助。
 
 ## Code Groups
 
-You can group multiple code blocks like this:
+您可以像这样对多个代码块进行分组：
 
-**Input**
+**输入**
 
 ````md
 ::: code-group
@@ -281,7 +285,7 @@ export default config
 :::
 ````
 
-**Output**
+**输出**
 
 ::: code-group
 
@@ -308,9 +312,9 @@ export default config
 
 :::
 
-You can also [import snippets](#import-code-snippets) in code groups:
+你也可以在代码组中 [导入代码片段](#import-code-snippets) 。
 
-**Input**
+**输入**
 
 ```md
 ::: code-group
@@ -326,7 +330,7 @@ You can also [import snippets](#import-code-snippets) in code groups:
 :::
 ```
 
-**Output**
+**输出**
 
 ::: code-group
 
@@ -336,7 +340,7 @@ You can also [import snippets](#import-code-snippets) in code groups:
 
 :::
 
-## Container
+## 容器（标签）
 
 ::: zh-CN
 
@@ -381,15 +385,15 @@ details
 
 :::
 
-## KaTeX
+## KaTeX语法支持
 
 ::: tip
 
-More information about $\KaTeX$ examples can be found [here](/examples/katex).
+有关更多KaTeX语法的信息可以在 [此处](/examples/katex) 找到。
 
 :::
 
-**Input**
+**输入**
 
 ```md
 When $a \ne 0$, there are two solutions to $(ax^2 + bx + c = 0)$ and they are
@@ -404,9 +408,9 @@ $$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
 | $\nabla \times \vec{\mathbf{B}} -\, \frac1c\, \frac{\partial\vec{\mathbf{E}}}{\partial t} = \frac{4\pi}{c}\vec{\mathbf{j}}    \nabla \cdot \vec{\mathbf{E}} = 4 \pi \rho$ | _wha?_                                                                                 |
 ```
 
-**Output**
+**输出**
 
-When $a \ne 0$, there are two solutions to $(ax^2 + bx + c = 0)$ and they are
+当 $a \ne 0$时，$(ax^2 + bx + c = 0)$ 有两个解，他们是
 $$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
 
 **Maxwell's equations:**
@@ -417,9 +421,9 @@ $$ x = {-b \pm \sqrt{b^2-4ac} \over 2a} $$
 | $\nabla \times \vec{\mathbf{E}}\, +\, \frac1c\, \frac{\partial\vec{\mathbf{B}}}{\partial t}  = \vec{\mathbf{0}}$                                                          | curl of $\vec{\mathbf{E}}$ is proportional to the rate of change of $\vec{\mathbf{B}}$ |
 | $\nabla \times \vec{\mathbf{B}} -\, \frac1c\, \frac{\partial\vec{\mathbf{E}}}{\partial t} = \frac{4\pi}{c}\vec{\mathbf{j}}    \nabla \cdot \vec{\mathbf{E}} = 4 \pi \rho$ | _wha?_                                                                                 |
 
-### Custom KaTeX Options
+### 自定义 KaTeX 选项
 
-> [KaTeX options](https://katex.org/docs/options.html)
+> [KaTeX选项](https://katex.org/docs/options.html)
 
 ```ts
 // valaxy.config.ts
@@ -436,13 +440,13 @@ export default defineValaxyConfig({
 })
 ```
 
-## Markdown File Inclusion<!--  -->
+## 包含MarkDown文件<!--  -->
 
 ::: tip
-You can also prefix the markdown path with `@`, it will act as the source root. By default, it's the Valaxy project root.
+你也可以在 markdown 路径前加上 `@`，它将作为源代码根目录。默认情况下，它是 Valaxy 项目的根目录。
 :::
 
-**Input**
+**输入**
 
 ```md
 ## Docs
@@ -451,88 +455,88 @@ You can also prefix the markdown path with `@`, it will act as the source root. 
 <!--@include: ./parts/basics.md-->
 ```
 
-**Part file**
+**部分文件**
 
 ::: code-group
 
 ```md [parts/basics.md]
-Some getting started stuff.
+一些入门知识。
 
-### Configuration
+### 配置
 
-Can be created using `.foorc.json`.
+可使用 `.foorc.json` 创建。
 ```
 
 ```md [TEST.md]
-I'm a TEST.
+我只是一个测试。
 ```
 
 :::
 
-**Equivalent code**
+**等效代码**
 
 ```md
-## Docs
+## 文档
 
-I'm a TEST.
-Some getting started stuff.
+我只是一个测试。
+一些入门知识。
 
-### Configuration
+### 配置
 
-Can be created using `.foorc.json`.
+可使用 `.foorc.json` 创建。
 ```
 
-It also supports selecting a line range:
+它还支持选择行范围：
 
-**Input**
+**输入**
 
 ```md
-## Docs
+## 文档
 
 <!--@include: @/TEST.md-->
 <!--@include: ./parts/basics.md{3,}-->
 ```
 
-**Part file**
+**部分文件**
 
 ::: code-group
 
 ```md [parts/basics.md]
-Some getting started stuff.
+一些入门知识。
 
-### Configuration
+### 配置
 
-Can be created using `.foorc.json`.
+可使用 `.foorc.json` 创建。
 ```
 
 ```md [TEST.md]
-I'm a TEST.
+我只是一个测试。
 ```
 
 :::
 
-**Equivalent code**
+**等效代码**
 
 ```md
-## Docs
+## 文档
 
-I'm a TEST.
-### Configuration
+我只是一个测试。
+### 配置
 
-Can be created using `.foorc.json`.
+可使用 `.foorc.json` 创建。
 ```
 
-The format of the selected line range can be: `{3,}`, `{,10}`, `{1,10}`
+所选行范围的格式可以是： `{3,}`, `{,10}`, `{1,10}`
 
 ::: warning
-Note that this does not throw errors if your file is not present. Hence, when using this feature make sure that the contents are being rendered as expected.
+请注意，如果文件不存在，该功能不会出错。因此，在使用此功能时，请确保内容已按预期渲染。
 :::
 
 ## UnoCSS
 
-We integrated [UnoCSS](https://unocss.dev), so you can use it in your markdown file.
+我们集成了 [UnoCSS](https://unocss.dev)，因此您可以在标记符文件中使用它。
 
-Freedom to control your layout!
+自由控制你的布局！
 
 > 更多配置见 [UnoCSS | 扩展配置](/guide/config/extend#unocss-presets)。
 


### PR DESCRIPTION
# 汉化 Valaxy MarkDown 教程页面的的内容
文档的英文页面是完整的，但是汉化并不完全，遂进行汉化。