### PR TITLE
fix: remove duplicate sidebar (#345)

### DIFF
--- a/packages/valaxy-theme-yun/layouts/post.vue
+++ b/packages/valaxy-theme-yun/layouts/post.vue
@@ -41,11 +41,6 @@ useSchemaOrg(
 </script>
 
 <template>
-  <YunSidebar v-if="$slots['sidebar-child']">
-    <slot name="sidebar-child" />
-  </YunSidebar>
-  <YunSidebar v-else />
-
   <RouterView v-slot="{ Component }">
     <component :is="Component">
       <template #main-header-after>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.


-->
Close #345.


### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
`default.vue` and `post.vue` both render the `YunAside` component,which causes sidebar to be duplicate.Removing the redundant sidebar in `post.vue` can solve this problem.
### Linked Issues

#345

<!-- ### Additional context -->
<!-- e.g. is there anything you'd like reviewers to focus on? -->


### Copilot Descriptions

copilot:all
