### PR TITLE
fix(theme-yun): incorrect ago value when ``fm.updated`` is not exist

### DIFF
--- a/packages/valaxy-theme-yun/components/YunMdTimeWarning.vue
+++ b/packages/valaxy-theme-yun/components/YunMdTimeWarning.vue
@@ -17,6 +17,14 @@ const updated = computed(() => {
   return dayjs(fm.value.updated || fm.value.date)
 })
 
+const ago = computed(() => {
+  const fromNow = updated.value.fromNow()
+  if (/^\d/.test(fromNow))
+    return ` ${fromNow}`
+  else
+    return fromNow
+})
+
 /**
  * when the post is updated more than 180 days ago, show a warning
  * default 180 days, you can set `time_warning` in frontmatter to change it
@@ -32,6 +40,6 @@ const time_warning = computed(() => {
 
 <template>
   <blockquote v-if="time_warning" class="yun-time-warning" op="80">
-    {{ t('post.time_warning', { ago: updated.fromNow() }) }}
+    {{ t('post.time_warning', { ago }) }}
   </blockquote>
 </template>

--- a/packages/valaxy-theme-yun/components/YunMdTimeWarning.vue
+++ b/packages/valaxy-theme-yun/components/YunMdTimeWarning.vue
@@ -13,12 +13,16 @@ dayjs.extend(relativeTime)
 
 const { t } = useI18n()
 
+const updated = computed(() => {
+  return dayjs(fm.value.updated || fm.value.date)
+})
+
 /**
  * when the post is updated more than 180 days ago, show a warning
  * default 180 days, you can set `time_warning` in frontmatter to change it
  */
 const time_warning = computed(() => {
-  const diff = dayjs().valueOf() - dayjs(fm.value.updated || fm.value.date).valueOf()
+  const diff = dayjs().valueOf() - updated.value.valueOf()
   if (typeof fm.value.time_warning === 'number')
     return diff > fm.value.time_warning
   else
@@ -28,6 +32,6 @@ const time_warning = computed(() => {
 
 <template>
   <blockquote v-if="time_warning" class="yun-time-warning" op="80">
-    {{ t('post.time_warning', { ago: dayjs(fm.updated).fromNow() }) }}
+    {{ t('post.time_warning', { ago: updated.fromNow() }) }}
   </blockquote>
 </template>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

修复了当 ``fm.updated`` 不存在时，``ago`` 的值获取错误的问题

### Linked Issues

无

<!-- ### Additional context -->
<!-- e.g. is there anything you'd like reviewers to focus on? -->


### Copilot Descriptions

copilot:all
