### PR TITLE
fix: override instead of merging ``items`` when customizing i18n

### DIFF
--- a/packages/valaxy/node/plugins/valaxy/index.ts
+++ b/packages/valaxy/node/plugins/valaxy/index.ts
@@ -70,9 +70,15 @@ function generateStyles(roots: string[], options: ResolvedValaxyOptions) {
 }
 
 function generateLocales(roots: string[]) {
-  const imports: string[] = [
-    'import { defu } from "defu"',
-    'const messages = { "zh-CN": {}, en: {} }',
+  const imports: string[] = [`
+import { createDefu } from "defu"
+const defu = createDefu((obj, key, value) => {
+  if (key === 'items' && Array.isArray(obj[key])) {
+    obj[key] = value
+    return true
+  }
+})
+const messages = { "zh-CN": {}, en: {} }`,
   ]
   const languages = ['zh-CN', 'en']
 


### PR DESCRIPTION
### Description

``defu`` 的默认行为导致当自定义的 i18n 文本包含插值语法时，其与内置节点合并成新数组，从而出现了文本重复的问题

### Linked Issues

resolve #381 

### Copilot Descriptions

copilot:all
