### PR TITLE
fix: make ``@include`` effective early to parse included markdown text

### DIFF
--- a/demo/yun/pages/posts/include.md
+++ b/demo/yun/pages/posts/include.md
@@ -1,0 +1,6 @@
+---
+title: "@include 测试"
+categories: Test
+---
+
+<!-- @include: ./markdown.md{9,} -->

--- a/packages/valaxy/node/plugins/markdown/markdownToVue.ts
+++ b/packages/valaxy/node/plugins/markdown/markdownToVue.ts
@@ -5,7 +5,7 @@ import type { PageData } from 'valaxy/types'
 import path from 'pathe'
 import type { ResolvedConfig } from 'vite'
 import type { ResolvedValaxyOptions } from '../../options'
-import { createTransformIncludes } from './transform/include'
+import { resolveTransformIncludes } from './transform/include'
 import { createScanDeadLinks } from './transform/dead-links'
 import { createTransformMarkdown } from './transform/markdown'
 import { generatePageData } from './transform/page-data'
@@ -68,7 +68,6 @@ export async function createMarkdownToVueRenderFn(
   // for dead link detection
   options.pages = options.pages.map(p => p.replace(/\.md$/, '').replace(/\/index$/, ''))
 
-  const transformIncludes = createTransformIncludes(options)
   const transformCodeBlock = createTransformCodeBlock(options)
   const transformMarkdown = createTransformMarkdown(options)
 
@@ -107,7 +106,7 @@ export async function createMarkdownToVueRenderFn(
     const pageData = await generatePageData(code, id, options)
 
     code = transformHexoTags(code, id)
-    const data = transformIncludes(code, id)
+    const data = resolveTransformIncludes(code, id)
     const includes = data.includes
     code = data.code
     code = transformCodeBlock(code)

--- a/packages/valaxy/node/plugins/markdown/transform/index.ts
+++ b/packages/valaxy/node/plugins/markdown/transform/index.ts
@@ -5,6 +5,7 @@ import type MarkdownIt from 'markdown-it'
 import type { ResolvedValaxyOptions } from '../../../options'
 import { highlight } from '../plugins/highlight'
 import { defaultCodeTheme, setupMarkdownPlugins } from '../setup'
+import { createTransformIncludes } from './include'
 import { transformMermaid } from './mermaid'
 
 export async function createMarkdownPlugin(
@@ -12,6 +13,8 @@ export async function createMarkdownPlugin(
 ): Promise<Plugin> {
   const mdOptions = options?.config.markdown || {}
   const theme = mdOptions.theme ?? defaultCodeTheme
+
+  const transformIncludes = createTransformIncludes(options)
 
   return Markdown({
     include: [/\.md$/],
@@ -51,9 +54,10 @@ export async function createMarkdownPlugin(
     },
 
     transforms: {
-      before(code, _id) {
+      before(code, id) {
         // features
         code = transformMermaid(code)
+        code = transformIncludes(code, id)
         // TODO: PlantUML
         // code = transformPlantUml(code, config.plantUmlServer)
 

--- a/packages/valaxy/node/plugins/markdown/utils/processInclude.ts
+++ b/packages/valaxy/node/plugins/markdown/utils/processInclude.ts
@@ -5,13 +5,11 @@
 
 import path from 'node:path'
 import fs from 'fs-extra'
-import { slash } from '@antfu/utils'
 
 export function processIncludes(
   srcDir: string,
   src: string,
   file: string,
-  includes: string[],
 ): string {
   const includesRE = /<!--\s*@include:\s*(.*?)\s*-->/g
   const rangeRE = /\{(\d*),(\d*)\}$/
@@ -37,9 +35,9 @@ export function processIncludes(
           )
           .join('\n')
       }
-      includes.push(slash(includePath))
+      content = `<!-- @included: ${m1} -->\n${content}`
       // recursively process includes in the content
-      return processIncludes(srcDir, content, includePath, includes)
+      return processIncludes(srcDir, content, includePath)
     }
     catch (error) {
       return m // silently ignore error if file is not present


### PR DESCRIPTION
### Description

在解析 Markdown 前处理 ``@include``，因为没法传递 ``includes`` 数组所以加了个占位注释到后面再合并

### Linked Issues

resolve #393

### Copilot Descriptions

copilot:all
