### PR TITLE
fix: dynamic scss import functionality

### DIFF
--- a/packages/valaxy-addon-meting/client/hook.ts
+++ b/packages/valaxy-addon-meting/client/hook.ts
@@ -1,3 +1,4 @@
+import { onMounted } from 'vue'
 import type { MetingOptions } from '../node/index'
 import { animationIn, autoHidden, handleOptions, useAPlayerMiniSwitcherEventListener } from './utils'
 import { setupHiddenLyricHidingObserver } from './observer'
@@ -10,7 +11,7 @@ export enum Hook {
 
 export function onMetingInit({ options }: MetingOptions) {
   handleOptions(options, {
-    animationIn: () => import('../style/animation-in.scss'),
+    animationIn: () => onMounted(() => import('./styles/animation-in.scss')),
   })
 }
 

--- a/packages/valaxy-addon-meting/client/styles/animation-in.scss
+++ b/packages/valaxy-addon-meting/client/styles/animation-in.scss
@@ -1,0 +1,6 @@
+.aplayer.aplayer-fixed.aplayer-narrow {
+  & .aplayer-body {
+    display: none;
+    left: -100px;
+  }
+}

--- a/packages/valaxy-addon-meting/package.json
+++ b/packages/valaxy-addon-meting/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valaxy-addon-meting",
   "global": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/YunYouJun/valaxy/tree/main/packages/valaxy-addon-meting",

--- a/packages/valaxy-addon-meting/style/animation-in.scss
+++ b/packages/valaxy-addon-meting/style/animation-in.scss
@@ -1,6 +1,0 @@
-.aplayer.aplayer-fixed.aplayer-narrow {
-	& .aplayer-body {
-		display: none;
-		left: -100px;
-	}
-}


### PR DESCRIPTION
I apologize for the error. The module was tested within the theme project instead of a single blog test, which led to the mistake. Specifically, enabling the `animationIn` option resulted in the error `Cannot find module xxx`. To ensure proper module import, I added `onMounted`. Additionally, I took the opportunity to update the formatting standards in the `animation-in.scss` file.
