### PR TITLE
fix: Sync time part of YunMdTimeWarning when locale is updated

### DIFF
--- a/packages/valaxy-theme-yun/components/YunMdTimeWarning.vue
+++ b/packages/valaxy-theme-yun/components/YunMdTimeWarning.vue
@@ -1,21 +1,20 @@
 <script lang="ts" setup>
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useFrontmatter } from 'valaxy'
 import { useI18n } from 'vue-i18n'
 
 import { differenceInMilliseconds, formatDistanceToNow } from 'date-fns'
 
 const fm = useFrontmatter()
-const { t } = useI18n()
+const { t, locale } = useI18n()
 
 const updated = computed(() => fm.value.updated || fm.value.date || new Date())
-const ago = computed(() => {
+const ago = ref('')
+
+watch(locale, () => {
   const fromNow = formatDistanceToNow(updated.value, { addSuffix: true })
-  if (/^\d/.test(fromNow))
-    return ` ${fromNow}`
-  else
-    return fromNow
-})
+  ago.value = /^\d/.test(fromNow) ? ` ${fromNow}` : fromNow
+}, { immediate: true })
 
 /**
  * when the post is updated more than 180 days ago, show a warning


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR makes `ago` in `YunMdTimeWarning` sync with `locale`, by watching `locale`'s changes.

### Linked Issues

Fixes #405

### Additional context

I know little about Vue, so I went with `watch` to avoid both duplicating the `date-fns` locale selection pattern and sneaking a `locale.value` dependency inside the `computed` property just to declare its dependency.

### Copilot Descriptions

copilot:all
