### PR TITLE
feat(theme-yun): allow toggling presence of site-author-status

### DIFF
--- a/packages/valaxy-theme-yun/components/YunOverview.vue
+++ b/packages/valaxy-theme-yun/components/YunOverview.vue
@@ -11,7 +11,7 @@ const router = useRouter()
     <div class="site-info" m="t-6">
       <RouterLink class="site-author-avatar" to="/about">
         <img class="rounded-full" :src="siteConfig.author.avatar" alt="avatar">
-        <span class="site-author-status" :title="siteConfig.author.status.message">{{ siteConfig.author.status.emoji }}</span>
+        <span v-if="siteConfig.author.status.emoji" class="site-author-status" :title="siteConfig.author.status.message || undefined">{{ siteConfig.author.status.emoji }}</span>
       </RouterLink>
       <div
         class="site-author-name leading-6"

--- a/packages/valaxy/types/config.ts
+++ b/packages/valaxy/types/config.ts
@@ -104,6 +104,10 @@ export interface SiteConfig {
      * @description 状态
      */
     status: {
+      /**
+       * Emoji representation of your status like '👨‍💻'
+       * @description 你的状态的 Emoji 表示，如 '👨‍💻'
+       */
       emoji: string
       /**
        * show when hover emoji


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Allow toggling presence of site-author-status, also optimizing display logic of status message

Now setting `siteConfig.author.status.emoji` to a falsy value will just remove the component, and `siteConfig.author.status.message` won't display when it's falsy (e.g. '')

Also provided helpful description for `siteConfig.author.status.emoji` in hope that people ~~won't try to fill `:books:` in like me~~

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Copilot Descriptions

copilot:all
