### PR TITLE
fix: wrapTable duplicate nesting

### DIFF
--- a/packages/valaxy/client/utils/wrap.ts
+++ b/packages/valaxy/client/utils/wrap.ts
@@ -14,6 +14,8 @@ export function wrap(el: HTMLElement, className: string) {
  */
 export function wrapTable(container: HTMLElement | Document = document) {
   container.querySelectorAll('table').forEach((el) => {
+    if (el.parentElement?.classList.contains('table-container'))
+      return
     const container = document.createElement('div')
     container.className = 'table-container'
     wrap(el, 'table-container')


### PR DESCRIPTION
When users update articles, [`onContentUpdated`](https://github.com/YunYouJun/valaxy/blob/971a11c48f3f02cf70717f7f070633afb5be3c30/packages/valaxy/client/components/ValaxyMd.vue#L17) may cause issues with nested duplication. For example, as shown below:

```html
<div class="table-container">
  <div class="table-container">
    <div class="table-container">
```

Although this issue may not seem apparent on the surface, we should address it promptly or handle it within `onContentUpdated`.