### PR TITLE
fix: site default frontmatter excerpt_type invalid

### DIFF
--- a/packages/valaxy/node/plugins/vueRouter.ts
+++ b/packages/valaxy/node/plugins/vueRouter.ts
@@ -185,7 +185,7 @@ export async function createRouterPlugin(valaxyApp: ValaxyNode) {
          */
         route.addToMeta({
           frontmatter: routerFM,
-          excerpt: mdFm.excerpt || (excerpt ? getExcerptByType(excerpt, mdFm.excerpt_type, mdIt) : ''),
+          excerpt: mdFm.excerpt || (excerpt ? getExcerptByType(excerpt, mdFm.excerpt_type || defaultFrontmatter.excerpt_type, mdIt) : ''),
         })
 
         // set layout


### PR DESCRIPTION

### Description

修复站点默认 frontmatter 的 excerpt_type 无效的问题

```js
//site.config.ts
export default defineSiteConfig({
  frontmatter: {
    excerpt_type: 'text' //无效，但是写在文章中是有效的
  },
})
```