### PR TITLE
feat(valaxy-theme-yun): make footer dynamic cloud configurable

### DIFF
--- a/packages/valaxy-theme-yun/components/YunFooter.vue
+++ b/packages/valaxy-theme-yun/components/YunFooter.vue
@@ -45,7 +45,7 @@ const footerIcon = computed(() => themeConfig.value.footer.icon || {
     bg="white dark:$va-c-bg-soft"
     text="center sm"
   >
-    <YunCloud class="absolute top--10 left-0 right-0" />
+    <YunCloud v-if="themeConfig.footer.cloud?.enable" class="absolute top--10 left-0 right-0" />
 
     <div v-if="themeConfig.footer.beian?.enable && themeConfig.footer.beian.icp" class="beian" m="y-2">
       <a href="https://beian.miit.gov.cn/" target="_blank" rel="noopener">

--- a/packages/valaxy-theme-yun/node/config.ts
+++ b/packages/valaxy-theme-yun/node/config.ts
@@ -51,6 +51,9 @@ export const defaultThemeConfig: ThemeConfig = {
 
   sidebar: null,
   footer: {
+    cloud: {
+      enable: true,
+    },
     since: 2022,
     icon: {
       enable: true,

--- a/packages/valaxy-theme-yun/types/index.d.ts
+++ b/packages/valaxy-theme-yun/types/index.d.ts
@@ -180,6 +180,15 @@ export interface ThemeConfig extends DefaultTheme.Config {
    */
   footer: Partial<{
     /**
+     * @en The flowing cloud on top of the footer (If you want change color of cloud, please change css var `--yun-c-cloud`)
+     * @zh 页脚上部的动态云
+     * @default { enable: true }
+     */
+    cloud: {
+      enable: boolean
+    }
+
+    /**
      * 建站于
      */
     since: number


### PR DESCRIPTION
### Description

Currently, the `banner.cloud.enable` configuration option appears to have no effect.

After comparing `valaxy-theme-yun` with [hexo-theme-yun](https://github.com/YunYouJun/hexo-theme-yun) , I noticed that the dynamic cloud feature has been moved from the bottom of the homepage to the top of the footer on all pages. To address this, I’ve introduced a new configuration option, `footer.cloud.enable`, which allows users to toggle this feature on or off.

To avoid any potential breaking changes, I have not modified the original `banner.cloud.enable` configuration option.
