### PR TITLE
fix(addon-waline): 插件无法显示 emoji 表情选项卡的问题

### DIFF
--- a/packages/valaxy-addon-waline/components/WalineClient.vue
+++ b/packages/valaxy-addon-waline/components/WalineClient.vue
@@ -21,7 +21,7 @@ const appStore = useAppStore()
 const route = useRoute()
 const { locale } = useI18n()
 const path = computed(() => props.options.path || route.path.replace(/\/$/, ''))
-const emoji = computed(() => getEmojis(props.options.cdn))
+const emoji = computed(() => getEmojis(props.options.cdn, props.options.types, props.options.emoji))
 
 onMounted(() => {
   const { pageview, comment } = props.options

--- a/packages/valaxy-addon-waline/types/index.ts
+++ b/packages/valaxy-addon-waline/types/index.ts
@@ -4,7 +4,9 @@ export interface WalineCustomOptions {
   /**
    * emoji cdn
    */
-  cdn?: string
+  cdn?: string,
+  emoji?: string[],
+  types?: string[],
 }
 
-export type WalineOptions = { cdn?: string } & WalineInitOptions
+export type WalineOptions = { cdn?: string, types?: string[], emoji?: string[] } & WalineInitOptions

--- a/packages/valaxy-addon-waline/utils/index.ts
+++ b/packages/valaxy-addon-waline/utils/index.ts
@@ -2,7 +2,14 @@
  * Get emojis cdn path
  * @param cdn
  * @param types
+ * @param emoji
  */
-export function getEmojis(cdn = '//unpkg.com/', types = ['bilibili', 'qq', 'weibo']) {
-  return types.map(type => `${cdn}@waline/emojis/${type}/`)
+export function getEmojis(cdn = '//unpkg.com/', types = ['bilibili', 'qq', 'weibo'], emoji?: string[]) {
+  if (!emoji || emoji.length === 0) {
+    return types.map(type => `${cdn}@waline/emojis/${type}/`);
+  } else {
+    const typePaths = types.map(type => `${cdn}@waline/emojis/${type}/`);
+    const emojiPaths = emoji.map(emoji => `${emoji}/`);
+    return [...typePaths, ...emojiPaths];
+  }
 }


### PR DESCRIPTION
#520 解决emoji表情选项卡问题
增加 `types`，`emoji` 参数
