### PR TITLE
fix:  katex lint error and snippet type error

### DIFF
--- a/packages/valaxy/node/plugins/markdown/plugins/markdown-it/katex.ts
+++ b/packages/valaxy/node/plugins/markdown/plugins/markdown-it/katex.ts
@@ -177,9 +177,9 @@ export default function math_plugin(md: any, options: KatexOptions) {
       return katex.renderToString(latex, options)
     }
     catch (error) {
-      if (options.throwOnError) {  
-        throw error  
-      } 
+      if (options.throwOnError) {
+        throw error
+      }
       console.warn(error)
       return latex
     }
@@ -195,10 +195,10 @@ export default function math_plugin(md: any, options: KatexOptions) {
       return `<p>${katex.renderToString(latex, options)}</p>`
     }
     catch (error) {
-      if (options.throwOnError) {  
-        throw error  
-      } 
-        console.warn(error)
+      if (options.throwOnError) {
+        throw error
+      }
+      console.warn(error)
       return latex
     }
   }

--- a/packages/valaxy/node/plugins/markdown/plugins/markdown-it/snippet.ts
+++ b/packages/valaxy/node/plugins/markdown/plugins/markdown-it/snippet.ts
@@ -9,7 +9,7 @@ interface SnippetToken {
   src?: [string, string]
 }
 
-declare module 'markdown-it/lib/token' {
+declare module 'markdown-it/lib/token.mjs' {
   interface Token extends SnippetToken {}
 }
 


### PR DESCRIPTION
## Description

- fix "no-trailing-spaces" error and indentation error in markdown-it/katex.ts
- fix "module 'markdown-it/lib/token' cannot be found" error in markdown-it/snippet.ts


## Linked Issues
CI workflow error

## Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
