### PR TITLE
fix: lint issues in katex.ts and remove src type in snippet.ts

### DIFF
--- a/packages/valaxy/node/plugins/markdown/plugins/markdown-it/katex.ts
+++ b/packages/valaxy/node/plugins/markdown/plugins/markdown-it/katex.ts
@@ -177,9 +177,9 @@ export default function math_plugin(md: any, options: KatexOptions) {
       return katex.renderToString(latex, options)
     }
     catch (error) {
-      if (options.throwOnError) {  
-        throw error  
-      } 
+      if (options.throwOnError) {
+        throw error
+      }
       console.warn(error)
       return latex
     }
@@ -195,10 +195,10 @@ export default function math_plugin(md: any, options: KatexOptions) {
       return `<p>${katex.renderToString(latex, options)}</p>`
     }
     catch (error) {
-      if (options.throwOnError) {  
-        throw error  
-      } 
-        console.warn(error)
+      if (options.throwOnError) {
+        throw error
+      }
+      console.warn(error)
       return latex
     }
   }

--- a/packages/valaxy/node/plugins/markdown/plugins/markdown-it/snippet.ts
+++ b/packages/valaxy/node/plugins/markdown/plugins/markdown-it/snippet.ts
@@ -4,15 +4,6 @@ import type { MarkdownEnv } from '../..'
 import fs from 'fs-extra'
 import path from 'pathe'
 
-// add type extension for markdown-it Token
-interface SnippetToken {
-  src?: [string, string]
-}
-
-declare module 'markdown-it/lib/token' {
-  interface Token extends SnippetToken {}
-}
-
 /**
  * raw path format: "/path/to/file.extension#region {meta} [title]"
  *    where #region, {meta} and [title] are optional


### PR DESCRIPTION
## Description

1. **Fix lint errors in `markdown-it/katex.ts`**
   - Resolved all `no-trailing-spaces` ESLint errors
   - Fixed indentation and spacing to comply with project style guidelines

2. **Remove src type in `markdown-it/snippet.ts`**
   - Because it caused a type error

## Linked CI Jobs

- [Job 43397817362](https://github.com/YunYouJun/valaxy/actions/runs/15421583163/job/43397817362)
- [Job 43397817335](https://github.com/YunYouJun/valaxy/actions/runs/15421583163/job/43397817335)

## Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
