### PR TITLE
docs: fix grammatical errors in documentation  

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pnpm create valaxy
 # yarn create valaxy
 ```
 
-For a example, you can see [demo/yun](./demo/yun/) folder.
+For an example, you can see [demo/yun](./demo/yun/) folder.
 
 ## Features
 

--- a/docs/pages/addons/write.md
+++ b/docs/pages/addons/write.md
@@ -1,5 +1,5 @@
 ---
-title: Write a Addon
+title: Write an Addon
 title_zh: 编写一个插件
 categories:
   - addon

--- a/docs/pages/guide/deploy.md
+++ b/docs/pages/guide/deploy.md
@@ -111,7 +111,7 @@ This is because when there is a directory with the same name, GitHub Pages will 
 ::: en
 When you use `pnpm create valaxy` to create a template project, it contains the file [`.github/workflows/gh-pages.yml`](https://github.com/YunYouJun/valaxy/blob/main/packages/create-valaxy/template-blog/.github/workflows/gh-pages.yml) for the CI workflow of GitHub Actions.
 
-- Select the Github repository, go to `Settings`-> `Action` -> `General` -> `Workflow permissions`, and select `read and write permissions`。
+- Select the Github repository, go to `Settings`-> `Action` -> `General` -> `Workflow permissions`, and select `read and write permissions`.
 - Push to your GitHub repository, and go to `Settings` -> `Pages`. Select `gh-pages` branch.
 
 > `gh-pages` has been automatically deployed by `.github/workflows/gh-pages.yml`.

--- a/docs/pages/guide/third-party/index.md
+++ b/docs/pages/guide/third-party/index.md
@@ -153,7 +153,7 @@ Valaxy provides a quick integration plug-in: [valaxy-addon-algolia](https://gith
 ::: en
 > Implementd based on [Aplayer](https://github.com/DIYgod/APlayer) and [MetingJS](https://github.com/metowolf/MetingJS)
 
-For example, add a song from Netease Cloud in a article:
+For example, add a song from Netease Cloud in an article:
 
 Enable it in the FrontMatter of the article:
 :::


### PR DESCRIPTION
## Description

- **README.md**: Changed "For a example" to "For an example"  
- **docs/pages/addons/write.md**: Changed "Write a Addon" to "Write an Addon" in title  
- **docs/pages/guide/third-party/index.md**: Changed "in a article" to "in an article"  

## Linked Issues


## Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
