### PR TITLE
docs: fix grammatical errors and spelling issues in documentation  

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pnpm create valaxy
 # yarn create valaxy
 ```
 
-For a example, you can see [demo/yun](./demo/yun/) folder.
+For an example, you can see [demo/yun](./demo/yun/) folder.
 
 ## Features
 

--- a/docs/pages/addons/write.md
+++ b/docs/pages/addons/write.md
@@ -1,5 +1,5 @@
 ---
-title: Write a Addon
+title: Write an Addon
 title_zh: 编写一个插件
 categories:
   - addon

--- a/docs/pages/dev/docs.md
+++ b/docs/pages/dev/docs.md
@@ -26,7 +26,7 @@ Valaxy 将中英文写一个 Markdown 文件中，因此您可以很容易地进
 :::
 
 <div>
-This is a example.
+This is an example.
 </div>
 ```
 

--- a/docs/pages/guide/deploy.md
+++ b/docs/pages/guide/deploy.md
@@ -111,7 +111,7 @@ This is because when there is a directory with the same name, GitHub Pages will 
 ::: en
 When you use `pnpm create valaxy` to create a template project, it contains the file [`.github/workflows/gh-pages.yml`](https://github.com/YunYouJun/valaxy/blob/main/packages/create-valaxy/template-blog/.github/workflows/gh-pages.yml) for the CI workflow of GitHub Actions.
 
-- Select the Github repository, go to `Settings`-> `Action` -> `General` -> `Workflow permissions`, and select `read and write permissions`。
+- Select the Github repository, go to `Settings`-> `Action` -> `General` -> `Workflow permissions`, and select `read and write permissions`.
 - Push to your GitHub repository, and go to `Settings` -> `Pages`. Select `gh-pages` branch.
 
 > `gh-pages` has been automatically deployed by `.github/workflows/gh-pages.yml`.

--- a/docs/pages/guide/third-party/index.md
+++ b/docs/pages/guide/third-party/index.md
@@ -153,7 +153,7 @@ Valaxy provides a quick integration plug-in: [valaxy-addon-algolia](https://gith
 ::: en
 > Implementd based on [Aplayer](https://github.com/DIYgod/APlayer) and [MetingJS](https://github.com/metowolf/MetingJS)
 
-For example, add a song from Netease Cloud in a article:
+For example, add a song from Netease Cloud in an article:
 
 Enable it in the FrontMatter of the article:
 :::

--- a/docs/pages/guide/why.md
+++ b/docs/pages/guide/why.md
@@ -191,7 +191,7 @@ iles 与 Valaxy 的一些基础结构功能很相似，它相比 Vitepress 拥�
 :::
 
 ::: en
-After completing the development of Valaxy's basic structures, I learned about iles from my group friend, which is very similar to many features I have archieved.
+After completing the development of Valaxy's basic structures, I learned about iles from my group friend, which is very similar to many features I have archived.
 
 It has more features than Vitepress and is also suitable for writing a document with more interaction.
 


### PR DESCRIPTION
## Description

1. Fixed 4 instances of incorrect article usage ("a" → "an" before vowel sounds)  
   - README.md: "For a example" → "For an example"  
   - addons/write.md: "Write a Addon" → "Write an Addon"  
   - guide/third-party/index.md: "in a article" → "in an article"  
   - dev/docs.md: "This is a example" → "This is an example"  
 
2. "read and write permissions。" to  "read and write permissions."

3. Fixed "archieved" → "archived" in docs/pages/guide/why.md  

## Linked Issues


## Additional context

### why.md:195: `archieved` → `archived` or `archieved` to `achieved`?