### PR TITLE
test(e2e): change baseURL from HTTPS to HTTP for localhost testing

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
     // baseURL: 'http://127.0.0.1:3000',
 
     // docs
-    baseURL: 'https://localhost:4859',
+    baseURL: 'http://localhost:4859',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',


### PR DESCRIPTION
### Description

- Update playwright.config.ts baseURL from https://localhost:4859 to http://localhost:4859,resolve SSL certificate warnings
- Aligns with actual dev server configuration which runs on HTTP：`playwright.config.ts:87`

### Linked Issues


### Additional context

In `dev.ts:57`, the server is configured with `host: remote ? '0.0.0.0' : 'localhost'` and there is no HTTPS configuration.
Although the documentation mentions that page encryption requires HTTPS (docs/pages/guide/page.md), this is a requirement for production environments, not test environments.
