### PR TITLE
fix: i18n title for themes + algolia hot key for theme-yun

### DIFF
--- a/demo/custom/valaxy-theme-custom/components/StarterArticle.vue
+++ b/demo/custom/valaxy-theme-custom/components/StarterArticle.vue
@@ -34,7 +34,7 @@ const prevPost = computed(() => posts.value[findCurrentIndex() + 1])
           md:text-5xl md:leading-14
         "
       >
-        {{ frontmatter.title }}
+        {{ tObject(frontmatter.title || '', locale) }}
       </h1>
     </header>
 

--- a/packages/valaxy-theme-yun/components/YunSearchTrigger.vue
+++ b/packages/valaxy-theme-yun/components/YunSearchTrigger.vue
@@ -16,7 +16,7 @@ function togglePopup() {
 
 const algoliaRef = ref()
 onMounted(() => {
-  // algolia has its own hotkey
+  // algolia has its own hotkey handling in YunAlgoliaSearch component
   if (isFuse.value)
     useHotKey('k', togglePopup)
 })

--- a/packages/valaxy-theme-yun/components/menu/YunNavMenuTitle.vue
+++ b/packages/valaxy-theme-yun/components/menu/YunNavMenuTitle.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { useFrontmatter, useSiteConfig } from 'valaxy'
+import { tObject, useFrontmatter, useSiteConfig } from 'valaxy'
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { useYunAppStore } from '../../stores'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 
 const yunApp = useYunAppStore()
 const fm = useFrontmatter()
@@ -64,10 +64,10 @@ function goToLink() {
           class="size-4"
           :class="fm.icon || 'i-ri-article-line'"
         />
-        <span class="truncate"> {{ fm.title }}</span>
+        <span class="truncate"> {{ tObject(fm.title || '', locale) }}</span>
       </div>
       <span v-if="fm.subtitle" class="font-light op-80">
-        {{ fm.subtitle }}
+        {{ tObject(fm.subtitle || '', locale) }}
       </span>
     </div>
     <span v-if="showSiteTitle" class="font-light truncate">

--- a/packages/valaxy-theme-yun/components/third/YunAlgoliaSearch.vue
+++ b/packages/valaxy-theme-yun/components/third/YunAlgoliaSearch.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { isEmptyAddon } from 'valaxy'
 import * as addonAlgolia from 'valaxy-addon-algolia'
+import { onMounted, onUnmounted } from 'vue'
 
 defineProps<{
   open: boolean
@@ -15,6 +16,40 @@ defineExpose({
   loaded,
   load,
   dispatchEvent,
+})
+
+function isEditingContent(event: KeyboardEvent): boolean {
+  const element = event.target as HTMLElement
+  const tagName = element.tagName
+
+  return (
+    element.isContentEditable
+    || tagName === 'INPUT'
+    || tagName === 'SELECT'
+    || tagName === 'TEXTAREA'
+  )
+}
+
+onMounted(() => {
+  const handleSearchHotKey = (event: KeyboardEvent) => {
+    if (
+      (event.key?.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey))
+      || (!isEditingContent(event) && event.key === '/')
+    ) {
+      event.preventDefault()
+      load()
+      // eslint-disable-next-line ts/no-use-before-define
+      remove()
+    }
+  }
+
+  const remove = () => {
+    window.removeEventListener('keydown', handleSearchHotKey)
+  }
+
+  window.addEventListener('keydown', handleSearchHotKey)
+
+  onUnmounted(remove)
 })
 </script>
 

--- a/packages/valaxy/node/plugins/preset.ts
+++ b/packages/valaxy/node/plugins/preset.ts
@@ -153,7 +153,7 @@ export async function ViteValaxyPlugins(
     }
   }
 
-  const customIcon = {
+  const builtinCustomIcon = {
     nodejs: 'vscode-icons:file-type-node',
     playwright: 'vscode-icons:file-type-playwright',
     typedoc: 'vscode-icons:file-type-typedoc',
@@ -161,10 +161,13 @@ export async function ViteValaxyPlugins(
   }
   plugins.push(
     groupIconVitePlugin({
-      customIcon,
-      ...valaxyConfig.groupIcons,
+      customIcon: {
+        ...builtinCustomIcon,
+        ...valaxyConfig.groupIcons?.customIcon,
+      },
       defaultLabels: [
         ...valaxyConfig.groupIcons?.defaultLabels || [],
+        ...Object.keys(builtinCustomIcon),
         ...Object.keys(valaxyConfig.groupIcons?.customIcon || {}),
       ],
     }),


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

1. Fixed i18n display error on nav's menutitle (fyi I have attached the image to reveal the problem):

  <img width="1104" height="118" alt="image" src="https://github.com/user-attachments/assets/8b5df26a-49fd-4a27-8285-b4acf1abdf7d" />
2. In addition, the algolia hot key is not enabled when first mounted in `theme-yun`
3. The group icons are not working appropriatly for code blocks in `theme-yun`


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

1. N/A, refer to https://github.com/YunYouJun/valaxy/commit/051e7fcf5064a0f5e9b416302d0ffc71ae72c96a
2. See #567 and https://github.com/WRXinYue/valaxy/commit/4a416642d0fffc1836b5a067137df8b425b83de6
3. See #557 and https://github.com/YunYouJun/valaxy/commit/f8f0e8df22b1b35699399d4d4330233d81cde12f

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
