### PR TITLE
feat(theme-yun): add padding to post card to reduce compactness

### DIFF
--- a/packages/valaxy-theme-yun/components/YunPostCard.vue
+++ b/packages/valaxy-theme-yun/components/YunPostCard.vue
@@ -44,7 +44,7 @@ const postTitle = computed(() => {
         loading="lazy"
       >
 
-      <div class="flex flex-col items-center relative" :class="post.cover && 'h-54'" w="full">
+      <div class="flex flex-col items-center relative px-6" :class="post.cover && 'h-54'" w="full">
         <AppLink
           class="post-title-link cursor-pointer"
           :to="post.path || ''"
@@ -86,7 +86,7 @@ const postTitle = computed(() => {
 
     <!-- always show -->
     <div
-      w="full" class="yun-card-actions flex justify-between"
+      w="full" class="yun-card-actions flex justify-between px-6"
       min-h="10"
       text="sm"
     >


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The post card was way too compact when it exhibits the html content of a post

<img width="1468" height="882" alt="7d5fd063e82a5e89c953972f5320e762" src="https://github.com/user-attachments/assets/e67bd726-ae09-4379-89f2-a81fa343f182" />

After adding some paddings, it gets better

<img width="1470" height="878" alt="f9a57713c6f8bb70aa18702971860996" src="https://github.com/user-attachments/assets/3e37a790-022b-45ac-9f1a-cec91aa1eb62" />

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
N/A


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
