### PR TITLE
fix: inject default labels to support custom code block icons at correct timing

### DIFF
--- a/packages/valaxy/node/plugins/markdown/plugins/markdown-it/titleCollector.ts
+++ b/packages/valaxy/node/plugins/markdown/plugins/markdown-it/titleCollector.ts
@@ -31,11 +31,7 @@ export function titleCollectorPlugin(md: MarkdownIt) {
 
     // Extract title from token.info before it gets modified by other plugins
     const title = extractTitle(token.info)
-
-    // Only collect actual titles (not language fallbacks)
-    if (title && title !== extractTitle('')) {
-      globalTitleCollector.add(title)
-    }
+    globalTitleCollector.add(title)
 
     // Call the original fence renderer
     return fence(...args)

--- a/packages/valaxy/node/plugins/markdown/setup.ts
+++ b/packages/valaxy/node/plugins/markdown/setup.ts
@@ -58,9 +58,9 @@ export async function setupMarkdownPlugins(
 
   // custom plugins
   md.use(highlightLinePlugin)
-    .use(titleCollectorPlugin)
     .use(preWrapperPlugin, { theme, siteConfig })
     .use(snippetPlugin, options?.userRoot)
+    .use(titleCollectorPlugin)
     .use(containerPlugin, {
       languages: siteConfig.languages,
       ...mdOptions?.container,


### PR DESCRIPTION
fix: inject default labels to support custom code block icons at correct timing, close #578

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Cannot inject the correct default labels to the custom icon plugin, which leads to lost custom code block icons

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
#578 and #573

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
