### PR TITLE
fix: excerpt_html dynamicComponent cache issue, close #583

### DIFF
--- a/packages/valaxy/client/components/ValaxyDynamicComponent.vue
+++ b/packages/valaxy/client/components/ValaxyDynamicComponent.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Component } from 'vue'
-import { compile, defineAsyncComponent, onMounted, shallowRef } from 'vue'
+import { compile, defineAsyncComponent, shallowRef, watch } from 'vue'
 
 const props = withDefaults(
   defineProps<{
@@ -23,9 +23,9 @@ async function createComponent() {
   dynamicComponent.value = defineAsyncComponent(() => Promise.resolve(componentDefinition))
 }
 
-onMounted(() => {
+watch(() => [props.templateStr, props.data], () => {
   createComponent()
-})
+}, { immediate: true })
 </script>
 
 <template>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

DynamicComponent that loads the excerpt_html on the home page view caches the rendered output based on the templateStr, so even if we change the templateStr later, the component won't render the new template.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

#583


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
