### PR TITLE
fix: expand fuse.js search to all pages

### DIFF
--- a/docs/pages/guide/third-party/index.md
+++ b/docs/pages/guide/third-party/index.md
@@ -33,6 +33,10 @@ export default defineSiteConfig({
     type: 'fuse',
   },
   fuse: {
+    /**
+     * 设置搜索的文件路径
+     */
+    // pattern: 'pages/**/*.md',
     options: {
       keys: ['title', 'tags', 'categories', 'excerpt', 'content'],
       /**

--- a/packages/valaxy/node/modules/fuse.ts
+++ b/packages/valaxy/node/modules/fuse.ts
@@ -21,7 +21,8 @@ import { setEnvProd } from '../utils/env'
 export async function generateFuseList(options: ResolvedValaxyOptions) {
   consola.start(`Generate List for Fuse Search by (${colors.cyan('fuse.js')}) ...`)
   // generate
-  const files = await fg(`${options.userRoot}/pages/**/*.md`)
+  const pattern = options.config.siteConfig.fuse.pattern || path.join(options.userRoot, 'pages/**/*.md')
+  const files = await fg(pattern)
 
   const posts: FuseListItem[] = []
   for await (const i of files) {

--- a/packages/valaxy/types/config.ts
+++ b/packages/valaxy/types/config.ts
@@ -181,6 +181,14 @@ export interface SiteConfig {
      */
     dataPath: string
     /**
+     * fast-glob pattern to match Fuse List Data
+     * @default `pages\/**\/*.md`
+     * ```ts
+     * await fg(`${userRoot}/pages/posts/**\/*.md`)
+     * ```
+     */
+    pattern?: string
+    /**
      * @see https://fusejs.io/api/options.html
      */
     options: FuseOptions<FuseListItem> & {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Previously, fuse.js only searched the `pages/posts` directory. But in most instances, not like blogs, documentation sites do not follow the `pages/posts` structure, which caused the search cache to not be generated (only an empty `[]`). This PR expands the search scope of fuse.js to the entire `pages` directory to ensure that the document content can be correctly retrieved.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
