### PR TITLE
docs: correct the link of AppLink.vue

### DIFF
--- a/docs/pages/guide/built-ins/index.md
+++ b/docs/pages/guide/built-ins/index.md
@@ -78,7 +78,7 @@ Built for theme developers (common users usually do not need to use them directl
 ### Others {lang="en"}
 
 ::: zh-CN
-- [`AppLink.vue`](https://github.com/YunYouJun/valaxy/blob/main/packages/valaxy/client/components/ValaxyCopyright.vue): 根据链接
+- [`AppLink.vue`](https://github.com/YunYouJun/valaxy/blob/main/packages/valaxy/client/components/AppLink.vue): 根据链接
   自动判断是否为站内链接，站内链接使用 `<router-link/>`，站外链接使用 `<a target="_blank"></a>`。
 - [`ValaxyCopyright.vue`](https://github.com/YunYouJun/valaxy/blob/main/packages/valaxy/client/components/ValaxyCopyright.vue): 文章中的
   版权信息

--- a/docs/pages/guide/built-ins/index.md
+++ b/docs/pages/guide/built-ins/index.md
@@ -94,8 +94,7 @@ Built for theme developers (common users usually do not need to use them directl
 
 ::: en
 
-- [`AppLink.vue`](https://github.com/YunYouJun/valaxy/blob/main/packages/valaxy/client/components/ValaxyCopyright.vue): The link automatically determines whether it is an intra-site link. Use `<router-link/>` for intra-site links and `<a target=" blank"></a>`for external links.
-
+- [`AppLink.vue`](https://github.com/YunYouJun/valaxy/blob/main/packages/valaxy/client/components/AppLink.vue): The link automatically determines whether it is an intra-site link. Use `<router-link/>` for intra-site links and `<a target=" blank"></a>`for external links.
 - [`ValaxyCopyright.vue`](https://github.com/YunYouJun/valaxy/blob/main/packages/valaxy/client/components/ValaxyCopyright.vue): The copyright information in the article.
 - [`ValaxyDecrypt.vue`](https://github.com/YunYouJun/valaxy/blob/main/packages/valaxy/client/components/ValaxyDecrypt.vue): Text decryption component
 - [`ValaxyGalleryDecrypt.vue`](https://github.com/YunYouJun/valaxy/blob/main/packages/valaxy/client/components/ValaxyGalleryDecrypt.vue): Picture decryption component


### PR DESCRIPTION
### Description

This PR fixes a typo in the docs that the link to `AppLink.vue` should be [AppLink.vue](https://github.com/YunYouJun/valaxy/blob/main/packages/valaxy/client/components/AppLink.vue) but actually is [ValaxyCopyright.vue](https://github.com/YunYouJun/valaxy/blob/main/packages/valaxy/client/components/ValaxyCopyright.vue)

### Linked Issues


### Additional context

I initially didn’t notice that the page has two language versions, so I used two separate commits to fix the typo. Sorry about that.
