### PR TITLE
fix: remove git+ prefix from repository URLs in footer and devtools

### DIFF
--- a/demo/custom/valaxy-theme-custom/components/StarterFooter.vue
+++ b/demo/custom/valaxy-theme-custom/components/StarterFooter.vue
@@ -18,7 +18,14 @@ const isThisYear = computed(() => {
   return year === themeConfig.value.footer.since
 })
 
-const poweredHtml = computed(() => t('footer.powered', [`<a href="${pkg.repository}" target="_blank" rel="noopener">Valaxy</a> v${pkg.version}`]))
+/**
+ * Remove git+ prefix from repository URL
+ */
+function normalizeRepositoryUrl(url: string) {
+  return url.replace(/^git\+/, '')
+}
+
+const poweredHtml = computed(() => t('footer.powered', [`<a href="${normalizeRepositoryUrl(pkg.repository.url)}" target="_blank" rel="noopener">Valaxy</a> v${pkg.version}`]))
 const footerIcon = computed(() => themeConfig.value.footer.icon!)
 </script>
 

--- a/packages/valaxy-theme-yun/components/YunFooter.vue
+++ b/packages/valaxy-theme-yun/components/YunFooter.vue
@@ -31,9 +31,16 @@ const isThisYear = computed(() => {
   return year === themeConfig.value.footer.since
 })
 
-const poweredHtml = computed(() => t('footer.powered', [`<a href="${pkg.repository.url}" target="_blank" rel="noopener">Valaxy</a> <span class="op-60">v${pkg.version}</span>`]))
+/**
+ * Remove git+ prefix from repository URL
+ */
+function normalizeRepositoryUrl(url: string) {
+  return url.replace(/^git\+/, '')
+}
+
+const poweredHtml = computed(() => t('footer.powered', [`<a href="${normalizeRepositoryUrl(pkg.repository.url)}" target="_blank" rel="noopener">Valaxy</a> <span class="op-60">v${pkg.version}</span>`]))
 const footerIcon = computed(() => themeConfig.value.footer.icon || {
-  url: pkg.repository.url,
+  url: normalizeRepositoryUrl(pkg.repository.url),
   name: 'i-ri-cloud-line',
   title: pkg.name,
 })
@@ -82,7 +89,7 @@ const footerIcon = computed(() => themeConfig.value.footer.icon || {
       <span>
         <span>{{ t('footer.theme') }}</span>
         <span mx-1>-</span>
-        <a :href="themeConfig.pkg.repository.url" :title="themeConfig.pkg.name" target="_blank">{{ capitalize(config.theme) }}</a>
+        <a :href="normalizeRepositoryUrl(themeConfig.pkg.repository.url)" :title="themeConfig.pkg.name" target="_blank">{{ capitalize(config.theme) }}</a>
         <span class="ml-1 op-60">v{{ themeConfig.pkg.version }}</span>
       </span>
     </div>

--- a/packages/valaxy/client/modules/devtools.ts
+++ b/packages/valaxy/client/modules/devtools.ts
@@ -6,6 +6,13 @@ import valaxyLogo from '../assets/images/valaxy-logo.png'
 // import {addCustomCommand, addCustomTab } from '@vue/devtools-api'
 
 /**
+ * Remove git+ prefix from repository URL
+ */
+function normalizeRepositoryUrl(url: string) {
+  return url.replace(/^git\+/, '')
+}
+
+/**
  * add when enable vue devtools
  * https://devtools-next.vuejs.org/plugins/api
  */
@@ -39,7 +46,7 @@ export async function addValaxyTabAndCommand() {
         icon: 'i-ri-github-fill',
         action: {
           type: 'url',
-          src: pkg.repository.url,
+          src: normalizeRepositoryUrl(pkg.repository.url),
         },
       },
       {

--- a/packages/valaxy/node/utils/addons.ts
+++ b/packages/valaxy/node/utils/addons.ts
@@ -12,6 +12,13 @@ export interface ReadAddonModuleOptions {
   cwd?: string
 }
 
+/**
+ * Remove git+ prefix from repository URL
+ */
+function normalizeRepositoryUrl(url: string) {
+  return url.replace(/^git\+/, '')
+}
+
 export async function parseAddons(addons: ValaxyAddons, userRoot = process.cwd()) {
   const spinner = ora(`Resolve ${colors.cyan('addons')} from ${colors.dim(userRoot)}`).start()
 
@@ -34,8 +41,10 @@ export async function parseAddons(addons: ValaxyAddons, userRoot = process.cwd()
   spinner.succeed()
   const resolvedAddons = Object.values(resolvers).filter(item => item.enable)
   resolvedAddons.forEach((addon, i) => {
+    const repoUrl = addon.pkg.repository?.url || addon.pkg.repository
+    const displayUrl = typeof repoUrl === 'string' ? normalizeRepositoryUrl(repoUrl) : repoUrl
     // eslint-disable-next-line no-console
-    console.log(`  ${i === resolvedAddons.length - 1 ? '└─' : '├─'} ${colors.yellow(addon.name)} ${colors.blue(`v${addon.pkg?.version}`)}${addon.global ? colors.cyan(' (global)') : ''} ${colors.dim(addon.pkg.homepage || addon.pkg.repository?.url || addon.pkg.repository || '')}`)
+    console.log(`  ${i === resolvedAddons.length - 1 ? '└─' : '├─'} ${colors.yellow(addon.name)} ${colors.blue(`v${addon.pkg?.version}`)}${addon.global ? colors.cyan(' (global)') : ''} ${colors.dim(addon.pkg.homepage || displayUrl || '')}`)
   })
   return resolvedAddons
 }


### PR DESCRIPTION
## Summary

Fixes #628

This PR fixes an issue where footer links and devtools links were displaying repository URLs with the "git+" prefix from package.json's repository field format (git+https://...), which caused browser errors when users clicked on them.

## Changes

- Added `normalizeRepositoryUrl()` helper function to remove the "git+" prefix from repository URLs
- Applied the fix to:
  - `YunFooter.vue`: All repository URL references (powered link, footer icon, theme link)
  - `StarterFooter.vue`: Valaxy repository URL in powered link
  - `devtools.ts`: GitHub link in Vue DevTools
  - `addons.ts`: Console output of addon repository URLs

## Test Plan

- Build the project successfully ✅
- Verify that footer links no longer contain "git+" prefix
- Verify that clicking footer links opens the correct URLs in the browser
- Verify that devtools GitHub link works correctly

## Screenshots

Before: Links showed `git+https://github.com/...` and caused browser errors
After: Links show clean `https://github.com/...` URLs and work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)