### PR TITLE
fix(mermaid): add mermaid dependencies to vite config for proper local rendering

### DIFF
--- a/packages/valaxy/node/build.ts
+++ b/packages/valaxy/node/build.ts
@@ -34,7 +34,7 @@ export async function ssgBuild(
     plugins: await ViteValaxyPlugins(valaxyApp),
     ssr: {
       // TODO: workaround until they support native ESM
-      noExternal: ['workbox-window', /vue-i18n/, '@vue/devtools-api'],
+      noExternal: ['workbox-window', /vue-i18n/, '@vue/devtools-api', '@braintree/sanitize-url'],
     },
   }
 

--- a/packages/valaxy/node/plugins/extendConfig.ts
+++ b/packages/valaxy/node/plugins/extendConfig.ts
@@ -41,6 +41,12 @@ const clientDeps = [
   'vanilla-lazyload',
 
   'valaxy > @vueuse/integrations/useFuse',
+
+  // mermaid dependencies
+  'd3',
+  'lodash-es',
+  '@braintree/sanitize-url',
+  'mermaid',
 ]
 
 /**


### PR DESCRIPTION
## Summary

Fixes #623 - Mermaid diagrams not rendering properly in local development mode.

This PR adds mermaid and its dependencies to Valaxy's default Vite configuration, eliminating the need for users to manually configure these dependencies in their own `valaxy.config.ts`.

## Changes

- Added mermaid dependencies (`d3`, `lodash-es`, `@braintree/sanitize-url`, `mermaid`) to `optimizeDeps.include` in `packages/valaxy/node/plugins/extendConfig.ts` for proper bundling in development mode
- Added `@braintree/sanitize-url` to `ssr.noExternal` in `packages/valaxy/node/build.ts` for SSR/production builds

## Problem

Users reported that mermaid diagrams would appear blank in local development mode but work correctly when deployed to GitHub Pages. The issue was caused by missing Vite optimization configuration for mermaid's dependencies.

## Solution

The workaround mentioned in the issue comments (adding these dependencies manually to user config) is now applied at the framework level, so all users benefit from this fix automatically.

## Test plan

- [x] Built core packages with `pnpm run build`
- [x] Verified linting passes with `pnpm lint`
- [x] Verified type checking passes with `pnpm typecheck`
- [x] Tested with demo site containing mermaid diagrams

## References

- Issue: #623
- Related discussion: https://github.com/YunYouJun/valaxy/issues/623#issuecomment-2576698685

🤖 Generated with [Claude Code](https://claude.com/claude-code)