### PR TITLE
fix: add general subpath alias for addon imports

### DIFF
--- a/packages/valaxy/node/plugins/extendConfig.ts
+++ b/packages/valaxy/node/plugins/extendConfig.ts
@@ -3,6 +3,7 @@ import type { ResolvedValaxyOptions } from '../types'
 import { dirname, join, resolve } from 'node:path'
 import { uniq } from '@antfu/utils'
 import { mergeConfig, searchForWorkspaceRoot } from 'vite'
+import { escapeRegExp } from '../build/bundle'
 import { getIndexHtml } from '../common'
 import { isKatexPluginNeeded } from '../config/valaxy'
 import { isInstalledGlobally, resolveImportPath, toAtFS } from '../utils'
@@ -209,7 +210,6 @@ export async function getAlias(options: ResolvedValaxyOptions): Promise<AliasOpt
   }
 
   options.addons.forEach((addon) => {
-    // without alias 'valaxy-addon-xxx/', import { xxx } from 'valaxy-addon-name' works well
     alias.push({
       find: `${addon.name}/client/`,
       replacement: `${toAtFS(`${resolve(addon.root)}`)}/client/`,
@@ -218,6 +218,14 @@ export async function getAlias(options: ResolvedValaxyOptions): Promise<AliasOpt
       find: `${addon.name}/App.vue`,
       replacement: `${toAtFS(resolve(addon.root))}/App.vue`,
     })
+    // general subpath: e.g. valaxy-addon-xxx/components/Foo.vue -> addonRoot/components/Foo.vue
+    // Use regex to avoid Vite's normalizeSingleAlias stripping trailing slashes
+    // from string aliases, which would make this collide with the bare import alias.
+    alias.push({
+      find: new RegExp(`^${escapeRegExp(addon.name)}/(.+)`),
+      replacement: `${toAtFS(resolve(addon.root))}/$1`,
+    })
+    // bare import: e.g. valaxy-addon-xxx -> addonRoot/client/index.ts
     alias.push({
       find: addon.name,
       replacement: `${toAtFS(resolve(addon.root))}/client/index.ts`,

--- a/test/addon.test.ts
+++ b/test/addon.test.ts
@@ -1,7 +1,11 @@
+import type { Alias } from 'vite'
 import process from 'node:process'
 import { describe, expect, it } from 'vitest'
+import { resolveOptions } from '../packages/valaxy/node'
+import { getAlias } from '../packages/valaxy/node/plugins/extendConfig'
 import { getAddonRoot, readAddonModule } from '../packages/valaxy/node/utils/addons'
 import pkg from './fixtures/addon/package.json'
+import { fixtureFolder } from './shared'
 
 describe('addon parse', () => {
   it('addon:read:module', async () => {
@@ -16,5 +20,54 @@ describe('addon parse', () => {
       pkg,
     }
     expect(options).toEqual(result)
+  })
+})
+
+describe('addon alias', () => {
+  it('should include general subpath alias for addon before bare import alias', async () => {
+    const options = await resolveOptions({ userRoot: fixtureFolder.userRoot })
+    // Inject a fake addon to test alias generation
+    options.addons = [{
+      enable: true,
+      name: 'valaxy-addon-test',
+      global: false,
+      root: '/fake/addon/root',
+      options: {},
+      props: {},
+      pkg: { name: 'valaxy-addon-test' } as any,
+    }]
+    const aliases = await getAlias(options) as Alias[]
+
+    // Find addon-specific aliases (both string and regex)
+    const addonAliases = aliases.filter((a) => {
+      if (typeof a.find === 'string')
+        return a.find.startsWith('valaxy-addon-test')
+      if (a.find instanceof RegExp)
+        return a.find.test('valaxy-addon-test/components/Foo.vue')
+      return false
+    })
+
+    // Should have: client/, App.vue, general subpath (regex), bare import
+    expect(addonAliases.length).toBeGreaterThanOrEqual(4)
+
+    // General subpath alias uses a regex to avoid Vite's trailing-slash normalization
+    const generalSubpathAlias = addonAliases.find(a => a.find instanceof RegExp)
+    const bareImportAlias = addonAliases.find(a => a.find === 'valaxy-addon-test')
+
+    // General subpath alias must exist and match subpath imports
+    expect(generalSubpathAlias).toBeDefined()
+    expect(generalSubpathAlias!.find).toBeInstanceOf(RegExp)
+    expect((generalSubpathAlias!.find as RegExp).test('valaxy-addon-test/components/Foo.vue')).toBe(true)
+    expect((generalSubpathAlias!.find as RegExp).test('valaxy-addon-test')).toBe(false)
+    expect(generalSubpathAlias!.replacement).toContain('/fake/addon/root/')
+
+    // Bare import alias must point to client/index.ts
+    expect(bareImportAlias).toBeDefined()
+    expect(bareImportAlias!.replacement).toContain('/fake/addon/root/client/index.ts')
+
+    // General subpath alias must come before bare import alias (so subpath imports match first)
+    const subpathIdx = aliases.indexOf(generalSubpathAlias!)
+    const bareIdx = aliases.indexOf(bareImportAlias!)
+    expect(subpathIdx).toBeLessThan(bareIdx)
   })
 })


### PR DESCRIPTION
## Summary

Fix addon subpath imports (e.g. `valaxy-addon-components/components/VCLiveTime.vue`) being incorrectly resolved to `client/index.ts/components/VCLiveTime.vue` (ENOENT).

### Root cause

In `getAlias()`, the bare addon alias `{ find: addon.name, replacement: '.../client/index.ts' }` uses Vite's prefix matching, which also matches subpath imports like `valaxy-addon-xxx/components/Foo.vue`, incorrectly appending the subpath to `client/index.ts`.

### Fix

Add a regex-based subpath alias `^{addon.name}/(.+)` **before** the bare import alias so subpath imports resolve to the addon root directory. Key details:

- **Regex instead of trailing-slash string**: Vite's `normalizeSingleAlias` strips trailing slashes from both `find` and `replacement` when both end with `/`, which would make a string alias `addon.name + '/'` collide with the bare `addon.name` alias. Using a regex avoids this normalization.
- **`escapeRegExp()`**: The addon name is escaped to prevent regex metacharacters in package names (e.g. `.`) from causing unintended matches.

Closes #655

## Test plan

- [x] New unit test verifies subpath regex alias exists, matches subpath imports, rejects bare imports, and is ordered before the bare import alias
- [x] All 159 unit tests pass
- [x] `build:demo` succeeds (SSG with addons including algolia, components, etc.)
- [x] CI green on Ubuntu and Windows (lint, typecheck, build, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)