### PR TITLE
refactor: unify transition duration design tokens

### DIFF
--- a/packages/valaxy-theme-press/components/PressAside.vue
+++ b/packages/valaxy-theme-press/components/PressAside.vue
@@ -48,7 +48,7 @@ const press = usePressAppStore()
   z-index: var(--pr-z-aside);
   width: var(--va-aside-width);
   transform: translateX(100%);
-  transition: box-shadow var(--va-transition-duration), opacity 0.25s,
+  transition: box-shadow var(--va-transition-duration), opacity var(--va-transition-duration),
   transform var(--va-transition-duration) cubic-bezier(0.19, 1, 0.22, 1);
 
   &.open {

--- a/packages/valaxy-theme-press/components/PressBackdrop.vue
+++ b/packages/valaxy-theme-press/components/PressBackdrop.vue
@@ -16,7 +16,7 @@ defineProps<{
   inset: 0;
   z-index: var(--pr-z-backdrop);
   background: rgba(0, 0, 0, .6);
-  transition: opacity 0.5s;
+  transition: opacity var(--va-transition-duration-moderate);
 
   .fade-enter-from,
   .fade-leave-to {
@@ -24,7 +24,7 @@ defineProps<{
   }
 
   .fade-leave-active {
-    transition-duration: .25s;
+    transition-duration: var(--va-transition-duration);
   }
 }
 

--- a/packages/valaxy-theme-press/components/PressCategory.vue
+++ b/packages/valaxy-theme-press/components/PressCategory.vue
@@ -69,7 +69,7 @@ const { $tO } = useValaxyI18n()
   a {
     // color: var(--va-c-text-light);
     color: var(--vp-c-text-2);
-    transition: all 0.2s;
+    transition: all var(--va-transition-duration-fast);
 
     &:hover {
       // color: var(--va-c-primary);

--- a/packages/valaxy-theme-press/components/PressFeature.vue
+++ b/packages/valaxy-theme-press/components/PressFeature.vue
@@ -47,7 +47,7 @@ const { t } = useI18n()
   width: 48px;
   height: 48px;
   font-size: 24px;
-  transition: background-color 0.25s;
+  transition: background-color var(--va-transition-duration);
 }
 
 .dark .icon {

--- a/packages/valaxy-theme-press/components/PressFuseSearchButton.vue
+++ b/packages/valaxy-theme-press/components/PressFuseSearchButton.vue
@@ -53,7 +53,7 @@ const { t } = useI18n()
   height: 2.75rem;
   cursor: pointer;
   color: var(--vp-c-text-2);
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--va-transition-duration-fast) cubic-bezier(0.4, 0, 0.2, 1);
   outline: none;
 
   &:hover {
@@ -86,7 +86,7 @@ const { t } = useI18n()
 .press-search-btn-icon {
   width: 1.25rem;
   height: 1.25rem;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--va-transition-duration-fast) cubic-bezier(0.4, 0, 0.2, 1);
   opacity: 0.8;
 
   .press-search-btn:hover & {
@@ -95,7 +95,7 @@ const { t } = useI18n()
 
   &--close {
     transform: rotate(0deg);
-    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: all var(--va-transition-duration-fast) cubic-bezier(0.4, 0, 0.2, 1);
 
     .press-search-btn:hover & {
       transform: rotate(90deg);

--- a/packages/valaxy-theme-press/components/PressFuseSearchModal.vue
+++ b/packages/valaxy-theme-press/components/PressFuseSearchModal.vue
@@ -201,7 +201,7 @@ function getResultKey(title: string | Record<string, string>): string {
   border-radius: 12px;
   border: 2px solid var(--vp-c-divider);
   box-shadow: 0 4px 20px rgb(0 0 0 / 0.1);
-  transition: all 0.2s ease;
+  transition: all var(--va-transition-duration-fast) ease;
 
   &:focus-within {
     border-color: var(--vp-c-brand);
@@ -247,7 +247,7 @@ function getResultKey(title: string | Record<string, string>): string {
   border: none;
   cursor: pointer;
   border-radius: 8px;
-  transition: all 0.2s ease;
+  transition: all var(--va-transition-duration-fast) ease;
   flex-shrink: 0;
 
   &:hover {
@@ -297,7 +297,7 @@ function getResultKey(title: string | Record<string, string>): string {
   padding: 1rem 1.25rem;
   color: var(--vp-c-text-1);
   text-decoration: none;
-  transition: all 0.2s ease;
+  transition: all var(--va-transition-duration-fast) ease;
   animation: slide-in-up 0.3s ease forwards;
   opacity: 0;
   transform: translateY(10px);
@@ -383,7 +383,7 @@ function getResultKey(title: string | Record<string, string>): string {
   color: var(--vp-c-text-3);
   margin-left: 0.75rem;
   flex-shrink: 0;
-  transition: all 0.2s ease;
+  transition: all var(--va-transition-duration-fast) ease;
 }
 
 .press-result-item:hover .press-result-arrow {
@@ -449,7 +449,7 @@ function getResultKey(title: string | Record<string, string>): string {
 
 .modal-enter-active,
 .modal-leave-active {
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: all var(--va-transition-duration) cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .modal-enter-from {

--- a/packages/valaxy-theme-press/components/PressGetStarted.vue
+++ b/packages/valaxy-theme-press/components/PressGetStarted.vue
@@ -34,7 +34,7 @@ const { t } = useI18n()
   span {
     display: block;
     margin-left: 0.3em;
-    transition: all 0.3s ease-in-out;
+    transition: all var(--va-transition-duration) ease-in-out;
   }
 
   .svg-wrapper {
@@ -46,7 +46,7 @@ const { t } = useI18n()
 
   .icon {
     transform-origin: center center;
-    transition: all 0.3s ease-in-out;
+    transition: all var(--va-transition-duration) ease-in-out;
 
     // mask
     mask-image: url('/favicon.svg');

--- a/packages/valaxy-theme-press/components/PressLocalNav.vue
+++ b/packages/valaxy-theme-press/components/PressLocalNav.vue
@@ -60,7 +60,7 @@ const { headers } = useOutline()
   border-bottom: 1px solid var(--pr-c-divider-light);
   width: 100%;
   background-color: var(--va-c-bg);
-  transition: border-color 0.5s;
+  transition: border-color var(--va-transition-duration-moderate);
 }
 
 @include screen('md') {
@@ -77,12 +77,12 @@ const { headers } = useOutline()
   font-size: 12px;
   font-weight: 500;
   color: var(--va-c-text-light);
-  transition: color 0.5s;
+  transition: color var(--va-transition-duration-moderate);
 }
 
 .menu:hover {
   color: var(--va-c-text);
-  transition: color 0.25s;
+  transition: color var(--va-transition-duration);
 }
 
 @include screen('md') {
@@ -105,12 +105,12 @@ const { headers } = useOutline()
   font-size: 12px;
   font-weight: 500;
   color: var(--pr-c-text-2);
-  transition: color 0.5s;
+  transition: color var(--va-transition-duration-moderate);
 }
 
 .top-link:hover {
   color: var(--pr-c-text-1);
-  transition: color 0.25s;
+  transition: color var(--va-transition-duration);
 }
 
 @include screen('md') {

--- a/packages/valaxy-theme-press/components/PressLocalNavOutlineDropdown.vue
+++ b/packages/valaxy-theme-press/components/PressLocalNavOutlineDropdown.vue
@@ -84,13 +84,13 @@ const { t } = useI18n()
   font-weight: 500;
   line-height: 24px;
   color: var(--vp-c-text-2);
-  transition: color 0.5s;
+  transition: color var(--va-transition-duration-moderate);
   position: relative;
 }
 
 .VPLocalNavOutlineDropdown button:hover {
   color: var(--vp-c-text-1);
-  transition: color 0.25s;
+  transition: color var(--va-transition-duration);
 }
 
 .VPLocalNavOutlineDropdown button.open {
@@ -144,11 +144,11 @@ const { t } = useI18n()
 }
 
 .flyout-enter-active {
-  transition: all .2s ease-out;
+  transition: all var(--va-transition-duration-fast) ease-out;
 }
 
 .flyout-leave-active {
-  transition: all .15s ease-in;
+  transition: all var(--va-transition-duration-fast) ease-in;
 }
 
 .flyout-enter-from,

--- a/packages/valaxy-theme-press/components/PressNavBar.vue
+++ b/packages/valaxy-theme-press/components/PressNavBar.vue
@@ -61,7 +61,7 @@ const homeLink = computed(() => hasLocales.value ? currentLocale.value.link : '/
   border-bottom: 1px solid var(--pr-c-divider-light);
   padding: 0 8px 0 24px;
   height: var(--pr-nav-height);
-  transition: border-color 0.5s;
+  transition: border-color var(--va-transition-duration-moderate);
   background-color: var(--pr-navbar-c-bg);
   z-index: var(--pr-z-nav);
 }

--- a/packages/valaxy-theme-press/components/PressNavBarAskAiButton.vue
+++ b/packages/valaxy-theme-press/components/PressNavBarAskAiButton.vue
@@ -29,7 +29,7 @@ defineProps<{
   .PressNavBarAskAiButton {
     height: auto;
     padding: 11.5px;
-    transition: color 0.3s ease;
+    transition: color var(--va-transition-duration) ease;
     background-color: var(--va-c-bg-alt);
     border-radius: 8px;
     font-size: 15px;

--- a/packages/valaxy-theme-press/components/PressNavBarHamburger.vue
+++ b/packages/valaxy-theme-press/components/PressNavBarHamburger.vue
@@ -62,7 +62,7 @@ defineEmits<{
 .pr-NavBarHamburger.active:hover .middle,
 .pr-NavBarHamburger.active:hover .bottom {
   background-color: var(--pr-c-text-2);
-  transition: top .25s, background-color .25s, transform .25s;
+  transition: top var(--va-transition-duration), background-color var(--va-transition-duration), transform var(--va-transition-duration);
 }
 
 .top,
@@ -72,7 +72,7 @@ defineEmits<{
   width: 16px;
   height: 2px;
   background-color: var(--pr-c-text-1);
-  transition: top .25s, background-color .5s, transform .25s;
+  transition: top var(--va-transition-duration), background-color var(--va-transition-duration-moderate), transform var(--va-transition-duration);
 }
 
 .top    { top: 0; left: 0; transform: translateX(0); }

--- a/packages/valaxy-theme-press/components/PressNavBarSearchButton.vue
+++ b/packages/valaxy-theme-press/components/PressNavBarSearchButton.vue
@@ -46,7 +46,7 @@ defineProps<{
   background: transparent;
   font-size: 20px;
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: border-color var(--va-transition-duration);
 }
 
 .PressSearchButton:hover {
@@ -91,7 +91,7 @@ defineProps<{
   height: 16px;
   color: var(--va-c-text-1);
   fill: currentcolor;
-  transition: color 0.5s;
+  transition: color var(--va-transition-duration-moderate);
 }
 
 .PressSearchButton:hover .PressSearchButton-icon svg {
@@ -113,7 +113,7 @@ defineProps<{
   font-size: 13px;
   font-weight: 500;
   color: var(--va-c-text-2);
-  transition: color 0.5s;
+  transition: color var(--va-transition-duration-moderate);
 }
 
 .PressSearchButton:hover .PressSearchButton-text {

--- a/packages/valaxy-theme-press/components/PressNavItemGroup.vue
+++ b/packages/valaxy-theme-press/components/PressNavItemGroup.vue
@@ -57,7 +57,7 @@ const { t } = useI18n()
 
 .group[aria-expanded="true"] .button {
   color: rgb(60 60 60 / 0.70);
-  transition: color 0.25s;
+  transition: color var(--va-transition-duration);
 
   .dark & {
     color: rgb(235 235 235 / 0.6)
@@ -72,9 +72,9 @@ const { t } = useI18n()
   opacity: 0;
   visibility: hidden;
   transition:
-    opacity 0.25s,
-    visibility 0.25s,
-    transform 0.25s;
+    opacity var(--va-transition-duration),
+    visibility var(--va-transition-duration),
+    transform var(--va-transition-duration);
   transform: translateX(-50%) translateY(calc(var(--pr-nav-height) / 2));
   border-radius: 12px;
   padding: 12px;

--- a/packages/valaxy-theme-press/components/PressNavItemGroupChild.vue
+++ b/packages/valaxy-theme-press/components/PressNavItemGroupChild.vue
@@ -33,7 +33,7 @@ defineProps<{
     font-weight: 600;
     color: rgb(60 60 60 / 0.33);
     white-space: nowrap;
-    transition: color 0.25s;
+    transition: color var(--va-transition-duration);
   }
 
   &:first-child {

--- a/packages/valaxy-theme-press/components/PressNavItemLink.vue
+++ b/packages/valaxy-theme-press/components/PressNavItemLink.vue
@@ -31,7 +31,7 @@ const { t } = useI18n()
   font-size: 14px;
   font-weight: 500;
   color: var(--pr-nav-text);
-  transition: color 0.25s;
+  transition: color var(--va-transition-duration);
 
   &:hover{
     color: var(--va-c-brand);

--- a/packages/valaxy-theme-press/components/PressNavScreen.vue
+++ b/packages/valaxy-theme-press/components/PressNavScreen.vue
@@ -43,18 +43,18 @@ const isLocked = useScrollLock(isClient ? document.body : null)
   width: 100%;
   background-color: var(--pr-nav-screen-bg-color);
   overflow-y: auto;
-  transition: background-color 0.5s;
+  transition: background-color var(--va-transition-duration-moderate);
   pointer-events: auto;
 }
 
 .pr-NavScreen.fade-enter-active,
 .pr-NavScreen.fade-leave-active {
-  transition: opacity 0.25s;
+  transition: opacity var(--va-transition-duration);
 }
 
 .pr-NavScreen.fade-enter-active .container,
 .pr-NavScreen.fade-leave-active .container {
-  transition: transform 0.25s ease;
+  transition: transform var(--va-transition-duration) ease;
 }
 
 .pr-NavScreen.fade-enter-from,

--- a/packages/valaxy-theme-press/components/PressNavScreenMenuGroup.vue
+++ b/packages/valaxy-theme-press/components/PressNavScreenMenuGroup.vue
@@ -58,7 +58,7 @@ function toggle() {
   border-bottom: 1px solid var(--pr-c-divider);
   height: 48px;
   overflow: hidden;
-  transition: border-color 0.5s;
+  transition: border-color var(--va-transition-duration-moderate);
 }
 
 .pr-nav-screen-menu-group .items {
@@ -94,7 +94,7 @@ function toggle() {
   font-size: 14px;
   font-weight: 500;
   color: var(--pr-c-text-1);
-  transition: color 0.25s;
+  transition: color var(--va-transition-duration);
 }
 
 .button:hover {
@@ -105,7 +105,7 @@ function toggle() {
   width: 14px;
   height: 14px;
   fill: var(--pr-c-text-2);
-  transition: fill 0.5s, transform 0.25s;
+  transition: fill var(--va-transition-duration-moderate), transform var(--va-transition-duration);
 }
 
 .group:first-child {

--- a/packages/valaxy-theme-press/components/PressNavScreenMenuGroupLink.vue
+++ b/packages/valaxy-theme-press/components/PressNavScreenMenuGroupLink.vue
@@ -27,7 +27,7 @@ const { t } = useI18n()
   font-size: 14px;
   font-weight: 400;
   color: var(--pr-c-text-1);
-  transition: color 0.25s;
+  transition: color var(--va-transition-duration);
 }
 
 .pr-nav-screen-menu-group-link:hover {

--- a/packages/valaxy-theme-press/components/PressNavScreenMenuGroupSection.vue
+++ b/packages/valaxy-theme-press/components/PressNavScreenMenuGroupSection.vue
@@ -32,6 +32,6 @@ defineProps<{
   font-size: 13px;
   font-weight: 700;
   color: var(--pr-c-text-2);
-  transition: color 0.25s;
+  transition: color var(--va-transition-duration);
 }
 </style>

--- a/packages/valaxy-theme-press/components/PressNavScreenMenuLink.vue
+++ b/packages/valaxy-theme-press/components/PressNavScreenMenuLink.vue
@@ -24,7 +24,7 @@ const closeScreen = inject('close-screen') as () => void
   font-size: 14px;
   font-weight: 500;
   color: var(--pr-c-text-1);
-  transition: border-color 0.25s, color 0.25s;
+  transition: border-color var(--va-transition-duration), color var(--va-transition-duration);
 }
 
 .pr-nav-screen-menu-link:hover {

--- a/packages/valaxy-theme-press/components/PressOutline.vue
+++ b/packages/valaxy-theme-press/components/PressOutline.vue
@@ -67,7 +67,7 @@ useActiveAnchor(container, marker)
   width: 1px;
   height: 18px;
   background-color: var(--va-c-brand);
-  transition: top 0.25s cubic-bezier(0, 1, 0.5, 1), background-color 0.5s, opacity 0.25s;
+  transition: top var(--va-transition-duration) cubic-bezier(0, 1, 0.5, 1), background-color var(--va-transition-duration-moderate), opacity var(--va-transition-duration);
   border-top-right-radius: 2px;
   border-bottom-right-radius: 2px;
 }
@@ -88,13 +88,13 @@ useActiveAnchor(container, marker)
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  transition: color 0.5s;
+  transition: color var(--va-transition-duration-moderate);
 }
 
 .outline-link:hover,
 .outline-link.active {
   color: var(--pr-aside-text-1);
-  transition: color 0.25s;
+  transition: color var(--va-transition-duration);
 }
 
 .visually-hidden {

--- a/packages/valaxy-theme-press/components/PressOutlineItem.vue
+++ b/packages/valaxy-theme-press/components/PressOutlineItem.vue
@@ -45,13 +45,13 @@ const { locale } = useI18n()
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  transition: color 0.5s;
+  transition: color var(--va-transition-duration-moderate);
   font-weight: 400;
 
   &:hover,
   &.active {
     color: var(--va-c-brand);
-    transition: color 0.25s;
+    transition: color var(--va-transition-duration);
   }
 
   .nested {

--- a/packages/valaxy-theme-press/components/PressPostActions.vue
+++ b/packages/valaxy-theme-press/components/PressPostActions.vue
@@ -181,7 +181,7 @@ function onSelect(key: string) {
   padding: 4px 10px;
   font-size: 12px;
   line-height: 1;
-  transition: color 0.2s, background 0.2s;
+  transition: color var(--va-transition-duration-fast), background var(--va-transition-duration-fast);
   white-space: nowrap;
 }
 
@@ -206,7 +206,7 @@ function onSelect(key: string) {
   color: var(--va-c-text-3);
   padding: 4px 6px;
   font-size: 14px;
-  transition: color 0.2s, background 0.2s;
+  transition: color var(--va-transition-duration-fast), background var(--va-transition-duration-fast);
 }
 
 .press-post-actions-trigger:hover {
@@ -245,7 +245,7 @@ function onSelect(key: string) {
   cursor: pointer;
   font-size: 13px;
   color: var(--va-c-text-2);
-  transition: background 0.15s, color 0.15s;
+  transition: background var(--va-transition-duration-fast), color var(--va-transition-duration-fast);
   outline: none;
 }
 

--- a/packages/valaxy-theme-press/components/PressSidebar.vue
+++ b/packages/valaxy-theme-press/components/PressSidebar.vue
@@ -162,13 +162,13 @@ const { hasSidebar } = useSidebar()
   overflow-y: auto;
   overflow-y: overlay;
   transform: translateX(-100%);
-  transition: opacity 0.5s, transform 0.25s ease;
+  transition: opacity var(--va-transition-duration-moderate), transform var(--va-transition-duration) ease;
 
   &.open {
     opacity: 1;
     transform: translateX(0);
-    transition: opacity 0.25s,
-                transform 0.5s cubic-bezier(0.19, 1, 0.22, 1);
+    transition: opacity var(--va-transition-duration),
+                transform var(--va-transition-duration-moderate) cubic-bezier(0.19, 1, 0.22, 1);
   }
 }
 
@@ -208,7 +208,7 @@ const { hasSidebar } = useSidebar()
     height: 32px;
     color: var(--vp-c-text-3);
     cursor: pointer;
-    transition: color 0.25s;
+    transition: color var(--va-transition-duration);
     flex-shrink: 0;
   }
 

--- a/packages/valaxy-theme-press/components/PressSidebarItem.vue
+++ b/packages/valaxy-theme-press/components/PressSidebarItem.vue
@@ -140,7 +140,7 @@ const htmlText = computed(() => t(props.item.text || ''))
   left: -17px;
   width: 2px;
   border-radius: 2px;
-  transition: background-color 0.25s;
+  transition: background-color var(--va-transition-duration);
 }
 
 .VPSidebarItem.level-2.is-active > .item > .indicator,
@@ -161,7 +161,7 @@ const htmlText = computed(() => t(props.item.text || ''))
   padding: 4px 0;
   line-height: 24px;
   font-size: 14px;
-  transition: color 0.25s;
+  transition: color var(--va-transition-duration);
 }
 
 .VPSidebarItem.level-0 .text {

--- a/packages/valaxy-theme-press/components/PressSocialLink.vue
+++ b/packages/valaxy-theme-press/components/PressSocialLink.vue
@@ -24,12 +24,12 @@ defineProps<{
   width: 36px;
   height: 36px;
   color: var(--pr-c-text-2);
-  transition: color 0.5s;
+  transition: color var(--va-transition-duration-moderate);
 }
 
 .pr-social-link:hover {
   color: var(--pr-c-text-1);
-  transition: color 0.25s;
+  transition: color var(--va-transition-duration);
 }
 
 .pr-social-link > :deep(svg) {

--- a/packages/valaxy-theme-press/components/PressSwitchAppearance.vue
+++ b/packages/valaxy-theme-press/components/PressSwitchAppearance.vue
@@ -25,7 +25,7 @@ const appStore = useAppStore()
   border-radius: 11px;
   border: 1px solid var(--pr-switch-divider);
   background-color: var(--pr-switch-bg);
-  transition: border-color 0.25s, background-color 0.25s;
+  transition: border-color var(--va-transition-duration), background-color var(--va-transition-duration);
 }
 
 .switch:hover {
@@ -41,7 +41,7 @@ const appStore = useAppStore()
   border-radius: 50%;
   background-color: #fff;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.06);
-  transition: background-color 0.25s, transform 0.25s;
+  transition: background-color var(--va-transition-duration), transform var(--va-transition-duration);
 }
 
 .dark .check {

--- a/packages/valaxy-theme-press/components/PressToggleLocale.vue
+++ b/packages/valaxy-theme-press/components/PressToggleLocale.vue
@@ -66,7 +66,7 @@ const open = ref(false)
 
 .group[aria-expanded="true"] .button {
   color: rgb(60 60 60 / 0.70);
-  transition: color 0.25s;
+  transition: color var(--va-transition-duration);
 
   .dark & {
     color: rgb(235 235 235 / 0.6)
@@ -81,9 +81,9 @@ const open = ref(false)
   opacity: 0;
   visibility: hidden;
   transition:
-    opacity 0.25s,
-    visibility 0.25s,
-    transform 0.25s;
+    opacity var(--va-transition-duration),
+    visibility var(--va-transition-duration),
+    transform var(--va-transition-duration);
   transform: translateX(-50%) translateY(calc(var(--pr-nav-height) / 2));
   border-radius: 12px;
   padding: 12px;
@@ -126,8 +126,8 @@ const open = ref(false)
     font-weight: 500;
     white-space: nowrap;
     transition:
-      background-color 0.25s,
-      color 0.25s;
+      background-color var(--va-transition-duration),
+      color var(--va-transition-duration);
 
     &:hover {
       background-color: #f1f1f1;

--- a/packages/valaxy-theme-press/styles/docsearch.css
+++ b/packages/valaxy-theme-press/styles/docsearch.css
@@ -86,7 +86,7 @@
 /* Sidepanel tweaks */
 .DocSearch-Sidepanel-Prompt--form {
   border-color: var(--docsearch-subtle-color);
-  transition: border-color 0.2s;
+  transition: border-color var(--va-transition-duration-fast);
 }
 
 .DocSearch-Sidepanel-Prompt--submit {

--- a/packages/valaxy-theme-press/styles/markdown.scss
+++ b/packages/valaxy-theme-press/styles/markdown.scss
@@ -20,7 +20,7 @@
     display: inline-block;
     text-decoration: none;
     border-bottom: 1px solid transparent;
-    transition: all 0.4s;
+    transition: all var(--va-transition-duration-moderate);
   }
 
   code:not(pre > code) {
@@ -49,7 +49,7 @@
   .markdown-body {
     a {
       text-decoration: inherit;
-      transition: all 0.4s;
+      transition: all var(--va-transition-duration-moderate);
 
       &:hover {
         text-decoration: underline;

--- a/packages/valaxy-theme-yun/components/YunAside.vue
+++ b/packages/valaxy-theme-yun/components/YunAside.vue
@@ -69,7 +69,7 @@ watch(() => [yun.rightSidebar.isOpen, yun.size.isXl], async () => {
   // width: var(--va-sidebar-width, 300px);
   width: 0;
   transform: translateX(100%);
-  transition: all 0.2s map.get($cubic-bezier, 'ease-in-out');
+  transition: all var(--va-transition-duration-fast) map.get($cubic-bezier, 'ease-in-out');
   max-height: calc(100vh - var(--yun-margin-top));
 
   // float panel

--- a/packages/valaxy-theme-yun/components/YunBackToTop.vue
+++ b/packages/valaxy-theme-yun/components/YunBackToTop.vue
@@ -62,7 +62,7 @@ const strokeOffset = computed(() => {
 }
 
 .progress-circle {
-  transition: 0.3s stroke-dashoffset;
+  transition: var(--va-transition-duration) stroke-dashoffset;
   transform: rotate(-90deg);
   transform-origin: 50% 50%;
 

--- a/packages/valaxy-theme-yun/components/YunDropdownMenu.vue
+++ b/packages/valaxy-theme-yun/components/YunDropdownMenu.vue
@@ -92,7 +92,7 @@ defineSlots<{
   cursor: pointer;
   font-size: 0.8rem;
   color: var(--va-c-text-2);
-  transition: background 0.15s, color 0.15s;
+  transition: background var(--va-transition-duration-fast), color var(--va-transition-duration-fast);
   outline: none;
 }
 

--- a/packages/valaxy-theme-yun/components/YunFullscreenMenu.vue
+++ b/packages/valaxy-theme-yun/components/YunFullscreenMenu.vue
@@ -49,8 +49,8 @@ const app = useAppStore()
 .slide-down-enter-active,
 .slide-down-leave-active {
   opacity: 1;
-  transition: transform 0.3s map.get($cubic-bezier, 'ease-in-out'),
-    opacity 0.2s map.get($cubic-bezier, 'ease-in-out');
+  transition: transform var(--va-transition-duration) map.get($cubic-bezier, 'ease-in-out'),
+    opacity var(--va-transition-duration-fast) map.get($cubic-bezier, 'ease-in-out');
   transform: translateY(0);
 }
 

--- a/packages/valaxy-theme-yun/components/YunFuseSearch.vue
+++ b/packages/valaxy-theme-yun/components/YunFuseSearch.vue
@@ -95,7 +95,7 @@ watch(() => props.open, () => {
   text-align: center;
   margin: 0;
   z-index: var(--yun-z-search-popup);
-  transition: 0.2s;
+  transition: var(--va-transition-duration-fast);
   background-color: var(--va-c-bg-opacity);
 }
 
@@ -112,7 +112,7 @@ watch(() => props.open, () => {
   font-family: var(--va-font-serif);
   font-weight: 900;
   text-align: center;
-  transition: all 0.2s;
+  transition: all var(--va-transition-duration-fast);
 
   &:focus {
     border-color: var(--va-c-text);

--- a/packages/valaxy-theme-yun/components/YunGirlItem.vue
+++ b/packages/valaxy-theme-yun/components/YunGirlItem.vue
@@ -68,7 +68,7 @@ useMotion(itemRef, {
       padding: 0.2rem;
       background-color: #fff;
       box-shadow: 0 0 1rem rgb(0 0 0 / 0.12);
-      transition: 0.5s;
+      transition: var(--va-transition-duration-moderate);
 
       &:hover {
         box-shadow: 0 0 2rem rgb(0 0 0 / 0.12);

--- a/packages/valaxy-theme-yun/components/YunLinks.vue
+++ b/packages/valaxy-theme-yun/components/YunLinks.vue
@@ -40,7 +40,7 @@ const { data } = useRandomData(props.links, props.random)
     justify-self: center;
     line-height: 1.5;
     margin: 0.5rem;
-    transition: 0.2s;
+    transition: var(--va-transition-duration-fast);
     color: var(--primary-color, black);
     border: 1px solid var(--primary-color, gray);
 
@@ -61,7 +61,7 @@ const { data } = useRandomData(props.links, props.random)
         border-radius: 50%;
         background-color: #fff;
         border: 1px solid var(--primary-color, gray);
-        transition: 0.5s;
+        transition: var(--va-transition-duration-moderate);
 
         &:hover {
           box-shadow: 0 0 20px rgb(0 0 0 / 0.1);

--- a/packages/valaxy-theme-yun/components/YunOutline.vue
+++ b/packages/valaxy-theme-yun/components/YunOutline.vue
@@ -60,7 +60,7 @@ useActiveAnchor(containerRef, marker)
   width: 4px;
   height: 18px;
   background-color: var(--va-c-brand);
-  transition: top 0.25s cubic-bezier(0, 1, 0.5, 1), background-color 0.5s, opacity 0.25s;
+  transition: top var(--va-transition-duration) cubic-bezier(0, 1, 0.5, 1), background-color var(--va-transition-duration-moderate), opacity var(--va-transition-duration);
   border-top-right-radius: 2px;
   border-bottom-right-radius: 2px;
 }
@@ -79,13 +79,13 @@ useActiveAnchor(containerRef, marker)
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  transition: color 0.5s;
+  transition: color var(--va-transition-duration-moderate);
 }
 
 .outline-link:hover,
 .outline-link.active {
   color: var(--va-c-brand);
-  transition: color 0.25s;
+  transition: color var(--va-transition-duration);
 }
 
 .visually-hidden {

--- a/packages/valaxy-theme-yun/components/YunOutlineItem.vue
+++ b/packages/valaxy-theme-yun/components/YunOutlineItem.vue
@@ -30,12 +30,12 @@ const { locale } = useI18n()
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      transition: color 0.5s;
+      transition: color var(--va-transition-duration-moderate);
 
       &:hover,
       &.active {
         color: var(--va-c-primary-lighter);
-        transition: color 0.25s;
+        transition: color var(--va-transition-duration);
       }
 
     }

--- a/packages/valaxy-theme-yun/components/YunOverlay.vue
+++ b/packages/valaxy-theme-yun/components/YunOverlay.vue
@@ -20,7 +20,7 @@ withDefaults(defineProps<{
   background-color: rgb(0 0 0 / 0.5);
   position: fixed;
   inset: 0;
-  transition: opacity 0.4s;
+  transition: opacity var(--va-transition-duration-moderate);
 }
 
 @include mobile {

--- a/packages/valaxy-theme-yun/components/YunPostActions.vue
+++ b/packages/valaxy-theme-yun/components/YunPostActions.vue
@@ -123,7 +123,7 @@ function onSelect(key: string) {
   color: var(--va-c-text-3);
   padding: 0.15rem;
   border-radius: 0.25rem;
-  transition: color 0.2s, background 0.2s;
+  transition: color var(--va-transition-duration-fast), background var(--va-transition-duration-fast);
   font-size: 1rem;
 }
 

--- a/packages/valaxy-theme-yun/components/YunPostNav.vue
+++ b/packages/valaxy-theme-yun/components/YunPostNav.vue
@@ -42,7 +42,7 @@ const nextTitle = useLocaleTitle(next)
     font-weight: bold;
     text-transform: uppercase;
     height: 3rem;
-    transition: 0.4s;
+    transition: var(--va-transition-duration-moderate);
 
     &:hover {
       background-color: rgba(var(--va-c-primary-rgb), 0.1);

--- a/packages/valaxy-theme-yun/components/author/YunAuthorAvatar.vue
+++ b/packages/valaxy-theme-yun/components/author/YunAuthorAvatar.vue
@@ -29,7 +29,7 @@ const siteConfig = useSiteConfig()
 .site-author-avatar {
   img {
     box-shadow: 0 0 10px rgba(black, 0.2);
-    transition: 0.4s;
+    transition: var(--va-transition-duration-moderate);
 
     &:hover {
       box-shadow: 0 0 30px rgba(var(--va-c-primary-rgb), 0.2);

--- a/packages/valaxy-theme-yun/components/collection/YunCollectionSidebar.vue
+++ b/packages/valaxy-theme-yun/components/collection/YunCollectionSidebar.vue
@@ -50,13 +50,13 @@ const { collection } = useCollection()
           padding: 4px 0;
           font-size: 14px;
           line-height: 24px;
-          transition: color .25s;
+          transition: color var(--va-transition-duration);
         }
 
         .indicator {
           border-radius: 2px;
           width: 2px;
-          transition: background-color .25s;
+          transition: background-color var(--va-transition-duration);
           position: absolute;
           top: 6px;
           bottom: 6px;

--- a/packages/valaxy-theme-yun/components/project/YunProjectLinkItem.vue
+++ b/packages/valaxy-theme-yun/components/project/YunProjectLinkItem.vue
@@ -27,13 +27,13 @@ defineProps<{
 .yun-project-link-item {
   position: relative;
   background-color: rgb(0 0 0 / 0.05);
-  transition: background-color 0.3s;
+  transition: background-color var(--va-transition-duration);
 
   &::before {
     content: '';
     position: absolute;
     background-color: var(--c-brand);
-    transition: all 0.3s map.get($cubic-bezier, 'ease-in');
+    transition: all var(--va-transition-duration) map.get($cubic-bezier, 'ease-in');
     bottom: 0;
     left: 0;
     right: 0;
@@ -44,7 +44,7 @@ defineProps<{
     content: '';
     position: absolute;
     background-color: var(--c-brand);
-    transition: all 0.3s map.get($cubic-bezier, 'ease-in');
+    transition: all var(--va-transition-duration) map.get($cubic-bezier, 'ease-in');
     inset: 0;
     opacity: 0.1;
     z-index: -1;

--- a/packages/valaxy-theme-yun/components/prologue/YunAEFrame.vue
+++ b/packages/valaxy-theme-yun/components/prologue/YunAEFrame.vue
@@ -98,7 +98,7 @@ onMounted(() => {
 
   .tl, .tr, .bl, .br {
     position: absolute;
-    transition: transform 0.6s map.get($cubic-bezier, 'ease-in');
+    transition: transform var(--va-transition-duration-slow) map.get($cubic-bezier, 'ease-in');
   }
 
   .tl {

--- a/packages/valaxy-theme-yun/components/site/YunSiteTitle.vue
+++ b/packages/valaxy-theme-yun/components/site/YunSiteTitle.vue
@@ -44,7 +44,7 @@ const { $t } = useValaxyI18n()
     height: 10px;
     opacity: 0;
     border: 2px solid;
-    transition: 0.3s;
+    transition: var(--va-transition-duration);
     transition-timing-function: cubic-bezier(0.17, 0.67, 0.05, 1.29);
   }
 

--- a/packages/valaxy-theme-yun/components/theme/nimbo/YunNimboNavMenu.vue
+++ b/packages/valaxy-theme-yun/components/theme/nimbo/YunNimboNavMenu.vue
@@ -124,7 +124,7 @@ const app = useAppStore()
   align-items: center;
   justify-content: space-between;
   height: var(--yun-nav-height, 50px);
-  transition: all 0.5s map.get($cubic-bezier, 'ease-in');
+  transition: all var(--va-transition-duration-moderate) map.get($cubic-bezier, 'ease-in');
 
   &.play {
     top: 0;

--- a/packages/valaxy-theme-yun/styles/animations/index.scss
+++ b/packages/valaxy-theme-yun/styles/animations/index.scss
@@ -14,7 +14,7 @@
 
 .v-enter-active,
 .v-leave-active {
-  transition: opacity .2s map.get($cubic-bezier, 'ease-in');
+  transition: opacity var(--va-transition-duration-fast) map.get($cubic-bezier, 'ease-in');
 }
 
 .v-enter-from,
@@ -25,7 +25,7 @@
 .fade-enter-active,
 .fade-leave-active {
   opacity: 1;
-  transition: opacity 0.5s ease;
+  transition: opacity var(--va-transition-duration-moderate) ease;
 }
 
 .fade-enter-from,
@@ -55,7 +55,7 @@
     height: 10px;
     opacity: 0;
     border: 2px solid;
-    transition: 0.3s;
+    transition: var(--va-transition-duration);
     transition-timing-function: cubic-bezier(0.17, 0.67, 0.05, 1.29);
   }
 

--- a/packages/valaxy-theme-yun/styles/common/markdown.scss
+++ b/packages/valaxy-theme-yun/styles/common/markdown.scss
@@ -98,8 +98,8 @@
     font-size: var(--va-code-font-size);
     color: var(--va-code-line-number-color);
     transition:
-      border-color 0.5s,
-      color 0.5s;
+      border-color var(--va-transition-duration-moderate),
+      color var(--va-transition-duration-moderate);
   }
 
   // table

--- a/packages/valaxy-theme-yun/styles/global.scss
+++ b/packages/valaxy-theme-yun/styles/global.scss
@@ -4,7 +4,7 @@
  * bg transition
  */
 html {
-  transition: background-color 0.6s;
+  transition: background-color var(--va-transition-duration-slow);
 }
 
 .clip {

--- a/packages/valaxy-theme-yun/styles/layout/post.scss
+++ b/packages/valaxy-theme-yun/styles/layout/post.scss
@@ -40,7 +40,7 @@
     height: 10px;
     opacity: 0;
     border: 2px solid;
-    transition: 0.3s;
+    transition: var(--va-transition-duration);
     transition-timing-function: cubic-bezier(0.17, 0.67, 0.05, 1.29);
   }
 

--- a/packages/valaxy-theme-yun/styles/widgets/banner.scss
+++ b/packages/valaxy-theme-yun/styles/widgets/banner.scss
@@ -92,7 +92,7 @@ $char-animation-duration: 0.4s;
   font-size: var(--banner-char-size, 1rem);
   background-color: var(--banner-char-bg-color);
   line-height: 1;
-  transition: all 0.3s ease-in-out;
+  transition: all var(--va-transition-duration) ease-in-out;
   transition-delay: 0s;
 
   &:hover {

--- a/packages/valaxy/client/components/ValaxyLogo.vue
+++ b/packages/valaxy/client/components/ValaxyLogo.vue
@@ -30,6 +30,6 @@ import valaxyLogoPng from '../assets/images/valaxy-logo.png'
   height: 150%;
   background-image: linear-gradient(-45deg, rgb(108, 34, 236) 50%, rgba(59,130,246,var(--un-to-opacity, 1)) 50%);
   opacity: 0.3;
-  transition: opacity 0.2s;
+  transition: opacity var(--va-transition-duration-fast);
 }
 </style>

--- a/packages/valaxy/client/components/ValaxyOverlay.vue
+++ b/packages/valaxy/client/components/ValaxyOverlay.vue
@@ -21,7 +21,7 @@ withDefaults(defineProps<{
   position: fixed;
   inset: 0;
   z-index: calc(var(--va-z-overlay) - 1);
-  transition: opacity 0.4s;
+  transition: opacity var(--va-transition-duration-moderate);
 
   &.fade-enter-from,
   &.fade-leave-to {

--- a/packages/valaxy/client/styles/common/code.scss
+++ b/packages/valaxy/client/styles/common/code.scss
@@ -80,12 +80,12 @@ html:not(.dark) .vp-code-dark {
     line-height: var(--va-code-line-height);
     font-size: var(--va-code-font-size);
     color: var(--va-code-block-color);
-    transition: color 0.5s;
+    transition: color var(--va-transition-duration-moderate);
   }
 
   [class*='language-'] code .highlighted {
     background-color: var(--va-code-line-highlight-color);
-    transition: background-color 0.5s;
+    transition: background-color var(--va-transition-duration-moderate);
     margin: 0 -24px;
     padding: 0 24px;
     width: calc(100% + 2 * 24px);
@@ -122,9 +122,9 @@ html:not(.dark) .vp-code-dark {
     background-size: 20px;
     background-repeat: no-repeat;
     transition:
-      border-color 0.25s,
-      background-color 0.25s,
-      opacity 0.25s;
+      border-color var(--va-transition-duration),
+      background-color var(--va-transition-duration),
+      opacity var(--va-transition-duration);
   }
 
   [class*='language-']:hover>button.copy,
@@ -184,8 +184,8 @@ html:not(.dark) .vp-code-dark {
     font-weight: 500;
     color: var(--va-code-lang-color);
     transition:
-      color 0.4s,
-      opacity 0.4s;
+      color var(--va-transition-duration-moderate),
+      opacity var(--va-transition-duration-moderate);
   }
 
   [class*='language-']:hover>button.copy+span.lang,
@@ -195,7 +195,7 @@ html:not(.dark) .vp-code-dark {
 
   // diff
   [class*='language-'] code .diff {
-    transition: background-color 0.5s;
+    transition: background-color var(--va-transition-duration-moderate);
     margin: 0 -24px;
     padding: 0 24px;
     width: calc(100% + 2 * 24px);

--- a/packages/valaxy/client/styles/common/hamburger.scss
+++ b/packages/valaxy/client/styles/common/hamburger.scss
@@ -22,7 +22,7 @@ $hamburger-size: 22px;
 .vt-hamburger.is-active:hover .vt-hamburger-middle,
 .vt-hamburger.is-active:hover .vt-hamburger-bottom {
   background-color: var(--va-c-primary);
-  transition: top .25s, background-color .25s, transform .25s;
+  transition: top var(--va-transition-duration), background-color var(--va-transition-duration), transform var(--va-transition-duration);
 }
 
 .vt-hamburger-container {
@@ -40,7 +40,7 @@ $hamburger-size: 22px;
   width: $hamburger-size;
   height: 2px;
   background-color: var(--va-c-primary);
-  transition: top .25s, background-color .5s, transform .25s;
+  transition: top var(--va-transition-duration), background-color var(--va-transition-duration-moderate), transform var(--va-transition-duration);
 }
 
 .vt-hamburger-top    { 

--- a/packages/valaxy/client/styles/common/markdown.scss
+++ b/packages/valaxy/client/styles/common/markdown.scss
@@ -69,8 +69,8 @@
     opacity: 0;
     text-decoration: none;
     transition:
-      color 0.25s,
-      opacity 0.25s;
+      color var(--va-transition-duration),
+      opacity var(--va-transition-duration);
   }
 
   .header-anchor::before {

--- a/packages/valaxy/client/styles/common/transition.scss
+++ b/packages/valaxy/client/styles/common/transition.scss
@@ -1,7 +1,7 @@
 .v {
   &-enter-active,
   &-leave-active {
-    transition: opacity var(--va-transition-duration, 0.4s) ease;
+    transition: opacity var(--va-transition-duration-moderate, 0.4s) ease;
   }
 
   &-enter-from,
@@ -13,7 +13,7 @@
 .fade {
   &-enter-active,
   &-leave-active {
-    transition: opacity var(--va-transition-duration, 0.4s) ease;
+    transition: opacity var(--va-transition-duration-moderate, 0.4s) ease;
   }
 
   &-enter-from,

--- a/packages/valaxy/client/styles/components/code-group.scss
+++ b/packages/valaxy/client/styles/components/code-group.scss
@@ -38,7 +38,7 @@
   color: var(--va-code-tab-text-color);
   white-space: nowrap;
   cursor: pointer;
-  transition: color 0.25s;
+  transition: color var(--va-transition-duration);
 }
 
 .vp-code-group .tabs label::after {
@@ -51,7 +51,7 @@
   border-radius: 2px;
   content: '';
   background-color: transparent;
-  transition: background-color 0.25s;
+  transition: background-color var(--va-transition-duration);
 }
 
 .vp-code-group label:hover {

--- a/packages/valaxy/client/styles/components/custom-block.scss
+++ b/packages/valaxy/client/styles/components/custom-block.scss
@@ -172,7 +172,7 @@
   color: inherit;
   font-weight: 600;
   text-underline-offset: 2px;
-  transition: opacity 0.25s;
+  transition: opacity var(--va-transition-duration);
 }
 
 .custom-block a:hover {

--- a/packages/valaxy/client/styles/vars.scss
+++ b/packages/valaxy/client/styles/vars.scss
@@ -28,10 +28,11 @@ $font: map.merge(
 $transition: () !default;
 $transition: map.merge(
   (
-    "duration-fast": 0.2s,
-    "duration": 0.4s,
+    "duration-fast": 0.15s,
+    "duration": 0.25s,
+    "duration-moderate": 0.4s,
     "duration-slow": 0.6s,
-    "": all var(--va-transition-duration-fast) ease-in-out,
+    "": all var(--va-transition-duration) ease-in-out,
   ),
   $transition
 );


### PR DESCRIPTION
## Summary

Resolves #659

Redesign the transition duration token system to match actual usage patterns. The previous system had ~17% token adoption (13 token uses vs 62+ hardcoded values) with misaligned tier definitions.

### New 4-tier token system

| Token | Old Value | New Value | Purpose |
|-------|-----------|-----------|---------|
| `--va-transition-duration-fast` | 0.2s | **0.15s** | Micro-interactions: color, opacity, small icons |
| `--va-transition-duration` | 0.4s | **0.25s** | Standard: component internal state changes |
| `--va-transition-duration-moderate` | *(new)* | **0.4s** | Moderate: card hover, panel expand |
| `--va-transition-duration-slow` | 0.6s | 0.6s | Slow: page-level transitions, large-area animations |
| `--va-transition` (shorthand) | `all var(--va-transition-duration-fast) ease-in-out` | `all var(--va-transition-duration) ease-in-out` | References default instead of fast |

### Changes

- Updated token definitions in `vars.scss` with the new 4-tier system
- Replaced **all hardcoded transition durations** (0.15s–0.6s) across **63 files** in:
  - `packages/valaxy/` (core framework)
  - `packages/valaxy-theme-press/` (Press theme)
  - `packages/valaxy-theme-yun/` (Yun theme)
- Preserved animation durations (≥0.8s, keyframes, SCSS variables) as-is
- Preserved timing functions, property names, and other transition parts

### Breaking Changes

- `--va-transition-duration-fast`: 0.2s → 0.15s
- `--va-transition-duration`: 0.4s → 0.25s
- `--va-transition` shorthand now references `--va-transition-duration` instead of `--va-transition-duration-fast`
- New `--va-transition-duration-moderate` (0.4s) added for previous default duration use cases

Users overriding these tokens or depending on their specific values should update accordingly.

## Test plan

- [x] ESLint passes
- [x] Unit tests pass (build-related test failures are pre-existing, unrelated to this change)
- [ ] Visual regression testing: verify transition smoothness across all themes
- [ ] Check that custom themes using the old token values still work (they can override via CSS custom properties)

🤖 Generated with [Claude Code](https://claude.com/claude-code)