### PR TITLE
fix: resolve blurry images after medium-zoom preview

### DIFF
--- a/packages/valaxy/client/composables/features/medium-zoom.ts
+++ b/packages/valaxy/client/composables/features/medium-zoom.ts
@@ -26,7 +26,7 @@ export function useMediumZoom() {
       // to force full-resolution rendering. Before closing, we restore the original
       // transform so the close animation works correctly.
       // @see https://github.com/francoischalifour/medium-zoom/issues/151
-      let savedTransform = ''
+      let savedStyles: { transform: string, width: string, height: string } | null = null
 
       zoom.on('opened', () => {
         const zoomed = document.querySelector('.medium-zoom-image--opened') as HTMLElement | null
@@ -42,7 +42,11 @@ export function useMediumZoom() {
         if (!scale || scale === 1)
           return
 
-        savedTransform = transform
+        savedStyles = {
+          transform,
+          width: zoomed.style.width,
+          height: zoomed.style.height,
+        }
         const rect = zoomed.getBoundingClientRect()
 
         // Replace scale transform with actual width/height
@@ -52,17 +56,17 @@ export function useMediumZoom() {
       })
 
       zoom.on('close', () => {
-        if (!savedTransform)
+        if (!savedStyles)
           return
 
         const zoomed = document.querySelector('.medium-zoom-image--opened') as HTMLElement | null
         if (zoomed) {
-          // Restore original transform for close animation
-          zoomed.style.transform = savedTransform
-          zoomed.style.width = ''
-          zoomed.style.height = ''
+          // Restore original styles for close animation
+          zoomed.style.transform = savedStyles.transform
+          zoomed.style.width = savedStyles.width
+          zoomed.style.height = savedStyles.height
         }
-        savedTransform = ''
+        savedStyles = null
       })
     })
   }


### PR DESCRIPTION
## Summary

- Fix blurry images (especially text) after medium-zoom preview in Chrome and other browsers (close #317)
- After the zoom open animation completes, replace CSS `transform: scale()` with actual `width`/`height` to force full-resolution rendering
- Restore original transform before the close animation so it animates correctly

## Root Cause

medium-zoom uses `transform: scale()` to animate images to their zoomed size. Browsers (especially Chrome) render scaled images at lower quality, causing noticeable blurriness on text-heavy images. This is a known upstream issue: https://github.com/francoischalifour/medium-zoom/issues/151

## Test plan

- [ ] Open a blog post with images containing text
- [ ] Click an image to zoom — verify it opens with smooth animation
- [ ] After zoom completes, verify the image is sharp (no blurry text)
- [ ] Click to close — verify it closes with smooth animation
- [ ] Test on Chrome, Firefox, and Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)