### PR TITLE
perf: parallelize addon/unocss config loading and use async file reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ valaxy-blog
 
 # codebuddy
 .codebuddy/memory
+.claude/worktrees

--- a/packages/valaxy/node/config/addon.ts
+++ b/packages/valaxy/node/config/addon.ts
@@ -15,19 +15,29 @@ export const defineAddon = defineValaxyAddon
 
 export async function resolveAddonsConfig(addons: ValaxyAddonResolver[], options: ResolvedValaxyOptions) {
   let valaxyConfig: ValaxyNodeConfig = {} as ValaxyNodeConfig
-  for (const addon of addons) {
-    // unconfig get node_modules/valaxy-addon-xxx/valaxy.config.ts(not exist) but get userRoot/valaxy.config.ts
-    // so we need to check if valaxy.config.ts exist
-    const addonConfigPath = path.resolve(addon.root, 'valaxy.config.ts')
-    if (!await fs.exists(addonConfigPath))
-      continue
 
-    const { config, configFile } = await resolveValaxyConfigFromRoot(addon.root, options)
-    if (!config)
-      continue
+  // Resolve all addon configs in parallel for faster startup
+  const results = await Promise.all(
+    addons.map(async (addon) => {
+      const addonConfigPath = path.resolve(addon.root, 'valaxy.config.ts')
+      if (!await fs.exists(addonConfigPath))
+        return null
 
-    addon.configFile = configFile
-    valaxyConfig = mergeValaxyConfig(config, valaxyConfig)
+      const { config, configFile } = await resolveValaxyConfigFromRoot(addon.root, options)
+      if (!config)
+        return null
+
+      return { addon, config, configFile }
+    }),
+  )
+
+  // Merge sequentially to preserve deterministic order
+  for (const result of results) {
+    if (!result)
+      continue
+    result.addon.configFile = result.configFile
+    valaxyConfig = mergeValaxyConfig(result.config, valaxyConfig)
   }
+
   return valaxyConfig
 }

--- a/packages/valaxy/node/plugins/unocss.ts
+++ b/packages/valaxy/node/plugins/unocss.ts
@@ -146,12 +146,22 @@ export async function createUnocssPlugin(options: ResolvedValaxyOptions) {
 
   const configDeps: string[] = []
 
-  for (const configFile of configFiles) {
-    if (await fs.exists(configFile)) {
-      const uConfig = (await jiti.import(configFile, { default: true })) as UnoCSSConfig
-      config = defu(config, uConfig)
+  // Load all config files in parallel via jiti for faster startup
+  const loadResults = await Promise.all(
+    configFiles.map(async (configFile) => {
+      if (await fs.exists(configFile)) {
+        const uConfig = (await jiti.import(configFile, { default: true })) as UnoCSSConfig
+        return { configFile, uConfig }
+      }
+      return null
+    }),
+  )
 
-      configDeps.push(configFile)
+  // Merge sequentially to preserve deterministic order
+  for (const result of loadResults) {
+    if (result) {
+      config = defu(config, result.uConfig)
+      configDeps.push(result.configFile)
     }
   }
 

--- a/packages/valaxy/node/plugins/vueRouter.ts
+++ b/packages/valaxy/node/plugins/vueRouter.ts
@@ -144,7 +144,7 @@ export async function createRouterPlugin(valaxyApp: ValaxyNode) {
       // find page path
       const path = route.components.get('default') || ''
       if (path.endsWith('.md')) {
-        const md = fs.readFileSync(path, 'utf-8')
+        const md = await fs.readFile(path, 'utf-8')
         const { data, excerpt, content } = matter(md, matterOptions)
         const mdFm = data as (Page | Post)
 


### PR DESCRIPTION
## Summary
- Parallelize addon config resolution (`resolveAddonsConfig`) with `Promise.all` instead of sequential `for` loop
- Parallelize UnoCSS jiti config file loading for faster startup
- Replace blocking `fs.readFileSync` with async `fs.readFile` in vueRouter `extendRoute`

All changes preserve deterministic merge order by collecting results in parallel then merging sequentially.

## Test plan
- [x] All 214 unit tests pass (`pnpm test`)
- [x] Core packages build successfully (`pnpm run build`)
- [ ] Manual: verify `pnpm docs:dev` starts correctly and pages render as expected
- [ ] Manual: verify `pnpm demo` works with theme-yun

🤖 Generated with [Claude Code](https://claude.com/claude-code)