### PR TITLE
fix(theme-yun): wrap URL-sourced links/girls in ClientOnly to fix SSG hydration mismatch

### DIFF
--- a/packages/valaxy-theme-yun/components/YunGirls.vue
+++ b/packages/valaxy-theme-yun/components/YunGirls.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import type { GirlType } from '../types'
+import { computed } from 'vue'
 import { useRandomData } from '../composables'
 
 const props = defineProps<{
@@ -8,11 +9,17 @@ const props = defineProps<{
 }>()
 
 const { data } = useRandomData(props.girls, props.random)
+const isUrlSource = computed(() => typeof props.girls === 'string')
 </script>
 
 <template>
   <div class="girls">
-    <ul class="girl-items">
+    <ClientOnly v-if="isUrlSource">
+      <ul class="girl-items">
+        <YunGirlItem v-for="girl, i in data" :key="i" :i="i" :girl="girl" />
+      </ul>
+    </ClientOnly>
+    <ul v-else class="girl-items">
       <YunGirlItem v-for="girl, i in data" :key="i" :i="i" :girl="girl" />
     </ul>
   </div>

--- a/packages/valaxy-theme-yun/components/YunGirls.vue
+++ b/packages/valaxy-theme-yun/components/YunGirls.vue
@@ -16,11 +16,11 @@ const isUrlSource = computed(() => typeof props.girls === 'string')
   <div class="girls">
     <ClientOnly v-if="isUrlSource">
       <ul class="girl-items">
-        <YunGirlItem v-for="girl, i in data" :key="i" :i="i" :girl="girl" />
+        <YunGirlItem v-for="girl, i in data" :key="girl.url" :i="i" :girl="girl" />
       </ul>
     </ClientOnly>
     <ul v-else class="girl-items">
-      <YunGirlItem v-for="girl, i in data" :key="i" :i="i" :girl="girl" />
+      <YunGirlItem v-for="girl, i in data" :key="girl.url" :i="i" :girl="girl" />
     </ul>
   </div>
 </template>

--- a/packages/valaxy-theme-yun/components/YunLinks.vue
+++ b/packages/valaxy-theme-yun/components/YunLinks.vue
@@ -23,8 +23,7 @@ const { data } = useRandomData(props.links, props.random)
  * errors or the list not appearing at all.
  *
  * For static array data the mismatch risk is lower (SSR and client render
- * the same initial order), so `<ClientOnly>` is not strictly necessary —
- * but we apply it uniformly for simplicity and safety.
+ * the same initial order), so `<ClientOnly>` is not applied.
  */
 const isUrlSource = computed(() => typeof props.links === 'string')
 </script>
@@ -39,7 +38,7 @@ const isUrlSource = computed(() => typeof props.links === 'string')
       <ul class="yun-link-items" flex="center wrap">
         <YunLinkItem
           v-for="link, i in data"
-          :key="i"
+          :key="link.url"
           :i="i" :link="link" :error-img="errorImg"
         />
       </ul>
@@ -47,7 +46,7 @@ const isUrlSource = computed(() => typeof props.links === 'string')
     <ul v-else class="yun-link-items" flex="center wrap">
       <YunLinkItem
         v-for="link, i in data"
-        :key="i"
+        :key="link.url"
         :i="i" :link="link" :error-img="errorImg"
       />
     </ul>

--- a/packages/valaxy-theme-yun/components/YunLinks.vue
+++ b/packages/valaxy-theme-yun/components/YunLinks.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import type { LinkType } from '../types'
+import { computed } from 'vue'
 import { useRandomData } from '../composables'
 
 const props = defineProps<{
@@ -12,11 +13,38 @@ const props = defineProps<{
 }>()
 
 const { data } = useRandomData(props.links, props.random)
+
+/**
+ * When links source is a URL (string), data is fetched asynchronously on the
+ * client side only.  During SSG the list is empty, but after hydration the
+ * fetched items are injected into the DOM.  Wrapping the list in
+ * `<ClientOnly>` avoids a hydration-mismatch between the static (empty) HTML
+ * and the client-rendered (populated) list, which could cause `replaceChild`
+ * errors or the list not appearing at all.
+ *
+ * For static array data the mismatch risk is lower (SSR and client render
+ * the same initial order), so `<ClientOnly>` is not strictly necessary —
+ * but we apply it uniformly for simplicity and safety.
+ */
+const isUrlSource = computed(() => typeof props.links === 'string')
 </script>
 
 <template>
   <div class="yun-links">
-    <ul class="yun-link-items" flex="center wrap">
+    <!--
+      Use ClientOnly when links are fetched from a URL to prevent
+      hydration mismatch (SSG renders empty list, client fills it).
+    -->
+    <ClientOnly v-if="isUrlSource">
+      <ul class="yun-link-items" flex="center wrap">
+        <YunLinkItem
+          v-for="link, i in data"
+          :key="i"
+          :i="i" :link="link" :error-img="errorImg"
+        />
+      </ul>
+    </ClientOnly>
+    <ul v-else class="yun-link-items" flex="center wrap">
       <YunLinkItem
         v-for="link, i in data"
         :key="i"


### PR DESCRIPTION
Closes #689

## Problem

When the `links` (or `girls`) prop of `YunLinks` / `YunGirls` is a **URL string**, the data is fetched asynchronously in `onMounted`. During SSG, the list renders empty (`data` is `undefined`). After hydration, the fetched data updates the reactive ref and Vue tries to patch the DOM — but the combination of `v-motion` directives, the `v-for` transition from empty to populated, and the SSG-hydrated DOM state can cause:

- `replaceChild` TypeError  
- Links not rendering at all on direct page load / refresh  
- Broken homepage styles when navigating back from the broken links page

The issue only manifests with `pnpm build` (SSG), not `pnpm dev` (SPA mode), and only when loading the links page directly or refreshing — SPA navigation from the homepage works fine because there's no SSG HTML to hydrate against.

## Fix

Wrap the `v-for` list in `<ClientOnly>` when the data source is a URL. This ensures:

1. **SSG**: No link items are rendered in the static HTML (no empty `v-for` fragment to mismatch against)
2. **Client**: The list is rendered purely on the client side after fetch completes, with no hydration conflict
3. **SPA navigation**: Behavior is unchanged (components are created fresh on the client)

For **static array** data sources (inline YAML links), the existing approach is preserved — SSR and client render the same initial order, so `<ClientOnly>` is not needed.

Applied the same fix to both `YunLinks.vue` and `YunGirls.vue` since they share the same `useRandomData` composable pattern.