### PR TITLE
docs: add valaxy-theme-shuimo to themes gallery

### DIFF
--- a/docs/pages/themes/gallery.md
+++ b/docs/pages/themes/gallery.md
@@ -79,6 +79,17 @@ themes:
       - blog
       - antfu
       - dark
+  - name: valaxy-theme-shuimo
+    icon: i-ri-quill-pen-line
+    repo: https://github.com/JobinJia/valaxy-theme-shuimo
+    desc: Chinese ink-wash (水墨) style theme for Valaxy
+    siteImage: https://raw.githubusercontent.com/JobinJia/valaxy-theme-shuimo/main/screenshots/preview-light.png
+    siteExampleUrl: 'https://jobinjia.com/'
+    tags:
+      - blog
+      - shuimo
+      - chinese
+      - ink-wash
 ---
 
 <ThemeGallery :themes="$frontmatter.themes" />


### PR DESCRIPTION
## Summary

- Add [valaxy-theme-shuimo](https://github.com/JobinJia/valaxy-theme-shuimo) to the themes gallery
- A Chinese ink-wash (水墨) style blog theme featuring xuan paper textures, brush strokes, seal stamps, and seasonal decorations

## Preview

| Light | Dark |
|-------|------|
| ![Light](https://raw.githubusercontent.com/JobinJia/valaxy-theme-shuimo/main/screenshots/home.png) | ![Dark](https://raw.githubusercontent.com/JobinJia/valaxy-theme-shuimo/main/screenshots/preview-dark.png) |

## npm

[@jobinjia/valaxy-theme-shuimo](https://www.npmjs.com/package/@jobinjia/valaxy-theme-shuimo)