### PR TITLE
Add food map addon gallery

### DIFF
--- a/docs/pages/addons/gallery.md
+++ b/docs/pages/addons/gallery.md
@@ -118,6 +118,15 @@ addons:
     tags:
       - cms
       - feishu
+  - name: valaxy-addon-food-map
+    author: CacheTide
+    icon: i-ri-map-pin-line
+    repo: https://github.com/CacheTide/valaxy-addon-food-map
+    desc: Build food maps from Markdown FrontMatter with shared JSON aggregation.
+    desc_zh: 从 Markdown FrontMatter 和共享 JSON 生成美食地图。
+    tags:
+      - food
+      - map
 ---
 
 <AddonGallery :addons="$frontmatter.addons" />

--- a/docs/pages/zh/addons/gallery.md
+++ b/docs/pages/zh/addons/gallery.md
@@ -107,6 +107,15 @@ addons:
     tags:
       - emoji
       - sticker
+  - name: valaxy-addon-food-map
+    author: CacheTide
+    icon: i-ri-map-pin-line
+    repo: https://github.com/CacheTide/valaxy-addon-food-map
+    desc: Build food maps from Markdown FrontMatter with shared JSON aggregation.
+    desc_zh: 从 Markdown FrontMatter 和共享 JSON 生成美食地图。
+    tags:
+      - map
+      - food
 ---
 
 <AddonGallery :addons="$frontmatter.addons" />


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Add `valaxy-addon-food-map` to the Valaxy addon gallery.

Links:

  - npm: https://www.npmjs.com/package/valaxy-addon-food-map
  - GitHub: https://github.com/CacheTide/valaxy-addon-food-map

Features:

  - Build a food map from Markdown FrontMatter
  - Render with `<ValaxyFoodMap />`
  - Export `/food-map/index.json`
  - Aggregate external food-map JSON sources
  - Shared JSON excludes visit timeline privacy fields such as `visits`, `visitedAt`, and `people`
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
Related issue: #693 
### Additional context
This PR follows the discussion in the related issue. Please let me know if the description, tags, or placement should be adjusted.
<!-- e.g. is there anything you'd like reviewers to focus on? -->
