### PR TITLE
fix(theme-press): resolve hydration mismatch with lazy hydration

### DIFF
--- a/packages/valaxy-theme-press/components/PressNavBarSearch.vue
+++ b/packages/valaxy-theme-press/components/PressNavBarSearch.vue
@@ -2,7 +2,7 @@
 import type { AlgoliaSearchOptions } from '../types/algolia'
 import { onKeyStroke } from '@vueuse/core'
 import { useAddonConfig, useSiteConfig } from 'valaxy'
-import { computed, defineAsyncComponent, onMounted, ref } from 'vue'
+import { computed, defineAsyncComponent, hydrateOnInteraction, onMounted, ref } from 'vue'
 import PressNavBarAskAiButton from './PressNavBarAskAiButton.vue'
 import PressNavBarSearchButton from './PressNavBarSearchButton.vue'
 
@@ -25,13 +25,25 @@ const PressAlgoliaSearch = isAlgolia.value
   ? defineAsyncComponent(() => import('./PressAlgoliaSearch.vue'))
   : () => null
 
-const PressFuseSearch = isFuse.value
-  ? defineAsyncComponent(() => import('./PressFuseSearch.vue'))
-  : () => null
+/**
+ * Use lazy hydration (Vue 3.5+) to avoid hydration mismatch.
+ *
+ * `defineAsyncComponent` without a hydration strategy causes mismatch because
+ * the SSR bundle resolves async components synchronously (real DOM), while the
+ * client hasn't loaded the chunk yet during hydration (comment placeholder).
+ *
+ * `hydrateOnInteraction` keeps code-splitting benefits and defers hydration
+ * until the user actually interacts with the search button.
+ */
+const PressFuseSearch = defineAsyncComponent({
+  loader: () => import('./PressFuseSearch.vue'),
+  hydrate: hydrateOnInteraction(['click', 'focusin']),
+})
 
-const PressLocalSearch = isLocal.value
-  ? defineAsyncComponent(() => import('./PressLocalSearch.vue'))
-  : () => null
+const PressLocalSearch = defineAsyncComponent({
+  loader: () => import('./PressLocalSearch.vue'),
+  hydrate: hydrateOnInteraction(['click', 'focusin']),
+})
 
 // #region Algolia lazy loading
 


### PR DESCRIPTION
## Summary

- Fix hydration mismatch error (`rendered on server: node / expected on client: Symbol(v-cmt)`) in `valaxy-theme-press`
- Use Vue 3.5+ **Lazy Hydration** (`hydrateOnInteraction`) for `PressFuseSearch` and `PressLocalSearch`

## Root Cause

`defineAsyncComponent` without a hydration strategy causes mismatch because:

- **SSR**: The server bundle resolves async components **synchronously** → renders real DOM nodes
- **Client hydration**: The async chunk hasn't loaded yet → renders a `<!---->` comment placeholder

This mismatch triggers: `[Vue warn]: Hydration node mismatch: rendered on server: node / expected on client: Symbol(v-cmt)`

## Fix

Use Vue 3.5+ [Lazy Hydration](https://vuejs.org/guide/components/async.html#lazy-hydration) with `hydrateOnInteraction`:

```ts
const PressFuseSearch = defineAsyncComponent({
  loader: () => import('./PressFuseSearch.vue'),
  hydrate: hydrateOnInteraction(['click', 'focusin']),
})
```

This approach:
- ✅ **Eliminates hydration mismatch** — SSR DOM is preserved as-is until interaction
- ✅ **Keeps code-splitting** — search components are still lazy-loaded
- ✅ **Better performance** — defers hydration until user actually needs search
- ✅ **Replays interaction** — the triggering click/focus is replayed after hydration

## Related

- Closes #695
- Also see: https://github.com/valaxyjs/valaxy-addon-git-log/pull/10 (fixes `git-log.json` fetch path for subpath deployments)

## Test plan

- [ ] Build a Valaxy site with `valaxy-theme-press` and `search.provider: 'fuse'`
- [ ] Verify no hydration mismatch warnings in browser console
- [ ] Verify search button click opens modal correctly (interaction replayed after hydration)
- [ ] Test with `vite.base: '/subpath/'` deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)