### PR TITLE
fix(valaxy): prevent stack overflow when encrypting long content

### DIFF
--- a/packages/valaxy/node/utils/encrypt.ts
+++ b/packages/valaxy/node/utils/encrypt.ts
@@ -34,6 +34,20 @@ function getCryptoDeriveKey(keyMaterial: CryptoKey | webcrypto.CryptoKey, salt: 
 }
 
 /**
+ * Convert a byte array to a binary string without using spread,
+ * which would otherwise overflow the call stack on long content.
+ *
+ * @see https://github.com/YunYouJun/valaxy/issues/699
+ */
+function bytesToBinaryString(bytes: Uint8Array) {
+  const CHUNK_SIZE = 0x8000
+  let result = ''
+  for (let i = 0; i < bytes.length; i += CHUNK_SIZE)
+    result += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK_SIZE) as unknown as number[])
+  return result
+}
+
+/**
  * @see https://github.com/mdn/dom-examples/blob/main/web-crypto/encrypt-decrypt/aes-cbc.js
  * @param content
  */
@@ -56,5 +70,5 @@ export async function encryptContent(content: string, options: {
     enc.encode(content),
   )
 
-  return String.fromCharCode(...new Uint8Array(ciphertextData))
+  return bytesToBinaryString(new Uint8Array(ciphertextData))
 }

--- a/packages/valaxy/node/utils/encrypt.ts
+++ b/packages/valaxy/node/utils/encrypt.ts
@@ -37,14 +37,19 @@ function getCryptoDeriveKey(keyMaterial: CryptoKey | webcrypto.CryptoKey, salt: 
  * Convert a byte array to a binary string without using spread,
  * which would otherwise overflow the call stack on long content.
  *
+ * `CHUNK_SIZE` of 32 KiB stays well under every mainstream JS engine's
+ * argument-count limit for `Function.prototype.apply` (V8 / JSC /
+ * SpiderMonkey all accept ≥65535 args), and is the same value used by
+ * `base64-js`, MDN's btoa example, and most binary-string utilities.
+ *
  * @see https://github.com/YunYouJun/valaxy/issues/699
  */
 function bytesToBinaryString(bytes: Uint8Array) {
   const CHUNK_SIZE = 0x8000
-  let result = ''
+  const chunks: string[] = []
   for (let i = 0; i < bytes.length; i += CHUNK_SIZE)
-    result += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK_SIZE) as unknown as number[])
-  return result
+    chunks.push(String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK_SIZE) as unknown as number[]))
+  return chunks.join('')
 }
 
 /**

--- a/test/encrypt.test.ts
+++ b/test/encrypt.test.ts
@@ -1,0 +1,58 @@
+import { webcrypto } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { encryptContent } from '../packages/valaxy/node/utils/encrypt'
+
+function getKeyMaterial(password: string) {
+  const enc = new TextEncoder()
+  return webcrypto.subtle.importKey(
+    'raw',
+    enc.encode(password),
+    'PBKDF2',
+    false,
+    ['deriveBits', 'deriveKey'],
+  )
+}
+
+function getCryptoDeriveKey(keyMaterial: webcrypto.CryptoKey, salt: Uint8Array) {
+  return webcrypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt,
+      iterations: 100000,
+      hash: 'SHA-256',
+    },
+    keyMaterial,
+    { name: 'AES-CBC', length: 256 },
+    true,
+    ['encrypt', 'decrypt'],
+  )
+}
+
+async function decrypt(pw: string, ciphertext: string, iv: Uint8Array, salt: Uint8Array) {
+  const keyMaterial = await getKeyMaterial(pw)
+  const key = await getCryptoDeriveKey(keyMaterial, salt)
+  const data = Uint8Array.from(ciphertext, c => c.charCodeAt(0))
+  const decrypted = await webcrypto.subtle.decrypt({ name: 'AES-CBC', iv }, key, data)
+  return new TextDecoder().decode(decrypted)
+}
+
+describe('encryptContent', () => {
+  const iv = webcrypto.getRandomValues(new Uint8Array(16))
+  const salt = webcrypto.getRandomValues(new Uint8Array(16))
+  const testPw = Math.random().toString(36).slice(2)
+
+  it('encrypts and decrypts short content', async () => {
+    const content = 'hello world'
+    const cipher = await encryptContent(content, { password: testPw, iv, salt })
+    expect(typeof cipher).toBe('string')
+    expect(await decrypt(testPw, cipher, iv, salt)).toBe(content)
+  })
+
+  // https://github.com/YunYouJun/valaxy/issues/699
+  it('encrypts large content without stack overflow', async () => {
+    const content = '爱你'.repeat(41400)
+    const cipher = await encryptContent(content, { password: testPw, iv, salt })
+    expect(typeof cipher).toBe('string')
+    expect(await decrypt(testPw, cipher, iv, salt)).toBe(content)
+  })
+})


### PR DESCRIPTION
## Summary

- `encryptContent` used `String.fromCharCode(...new Uint8Array(ciphertextData))`. The spread pushes every byte as a separate argument, which overflows the JS engine's argument limit once the encrypted payload exceeds ~32KB.
- For a Chinese-language article ≥~11.6k characters (UTF-8 ≈ 3 bytes each), the build fails with `RangeError: Maximum call stack size exceeded`.
- Converted bytes → binary string in 32KB chunks. Output stays byte-identical, so the existing client-side `useDecrypt` (which reads via `c.charCodeAt(0)`) keeps working without changes.

Closes #699

## Test plan

- [x] `pnpm test` — 290 tests pass, including new `test/encrypt.test.ts` that roundtrips a 41,400-repetition "爱你" payload (the exact size reported in #699)
- [x] `pnpm typecheck` passes
- [x] Lint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)