### PR TITLE
fix(valaxy): make vue-router & SSG server bundle resolve under pnpm (close #704)

### DIFF
--- a/packages/valaxy/node/build/ssg.ts
+++ b/packages/valaxy/node/build/ssg.ts
@@ -64,6 +64,23 @@ export function defaultIncludedRoutes(paths: string[]): string[] {
   return paths.filter(i => !i.includes(':') && !i.includes('*'))
 }
 
+/**
+ * SSR options for the built-in SSG server build.
+ *
+ * `noExternal: true` bundles ALL dependencies into the server bundle. The engine
+ * writes that bundle to `<outDir>/.vite-ssg-temp/entry-ssr.mjs` and loads it via a
+ * native `import()`; any externalized bare import would then be resolved by Node
+ * relative to the temp dir. Under pnpm's default (strict, non-hoisted) layout, deep
+ * transitive deps (e.g. `@vue/runtime-dom`, `@intlify/core-base`) are not surfaced
+ * at `<project>/node_modules/`, so those imports fail with `ERR_MODULE_NOT_FOUND`.
+ * A selective `noExternal` list doesn't help — a bundled package still externalizes
+ * its own transitive deps. Bundling everything makes the server bundle self-contained.
+ * See: https://github.com/YunYouJun/valaxy/issues/704 (same pnpm root cause)
+ */
+export function getSsgSsrConfig(): InlineConfig['ssr'] {
+  return { noExternal: true }
+}
+
 export interface ValaxySSGOptions {
   concurrency?: number
   onBeforePageRender?: (route: string, html: string) => Promise<string | void> | string | void
@@ -130,7 +147,6 @@ export async function ssgBuild(
     }
   }
 
-  const cdnModuleNames = (options.config.cdn?.modules || []).map((m: any) => m.name)
   const configOutDir = (viteConfig.build?.outDir as string) || 'dist'
   const outDir = isAbsolute(configOutDir) ? configOutDir : resolve(options.userRoot, configOutDir)
   const ssgTemp = resolve(outDir, '.vite-ssg-temp')
@@ -138,9 +154,9 @@ export async function ssgBuild(
   const defaultConfig: InlineConfig = {
     ...defaultViteConfig,
     plugins: await ViteValaxyPlugins(valaxyApp),
-    ssr: {
-      noExternal: ['workbox-window', /vue-i18n/, '@vue/devtools-api', ...cdnModuleNames],
-    },
+    // `ssr.noExternal` only affects the server build (step 2) — the client build
+    // ignores it. See `getSsgSsrConfig` for why everything is bundled.
+    ssr: getSsgSsrConfig(),
     build: {
       sourcemap: false,
       // Explicitly disable watch to prevent chokidar from opening too many

--- a/packages/valaxy/node/build/ssg.ts
+++ b/packages/valaxy/node/build/ssg.ts
@@ -75,7 +75,10 @@ export function defaultIncludedRoutes(paths: string[]): string[] {
  * at `<project>/node_modules/`, so those imports fail with `ERR_MODULE_NOT_FOUND`.
  * A selective `noExternal` list doesn't help — a bundled package still externalizes
  * its own transitive deps. Bundling everything makes the server bundle self-contained.
- * See: https://github.com/YunYouJun/valaxy/issues/704 (same pnpm root cause)
+ *
+ * This is a distinct failure mode from the browser-side bare-import error in #704
+ * (https://github.com/YunYouJun/valaxy/issues/704), but shares the same root cause:
+ * pnpm's strict (non-hoisted) `node_modules` layout.
  */
 export function getSsgSsrConfig(): InlineConfig['ssr'] {
   return { noExternal: true }

--- a/packages/valaxy/node/plugins/extendConfig.ts
+++ b/packages/valaxy/node/plugins/extendConfig.ts
@@ -133,7 +133,13 @@ export function createConfigPlugin(options: ResolvedValaxyOptions): Plugin {
         define: mergedDefine,
         resolve: {
           alias: await getAlias(options),
-          dedupe: ['vue', 'vue-router'],
+          // Dedupe the shared singletons that valaxy owns (it calls `createApp`,
+          // `createRouter`, `createPinia`, `createI18n`) but themes/addons also
+          // import. A second physical copy — e.g. resolved from a theme/addon that
+          // doesn't surface valaxy's copy under pnpm — would mean `useI18n()` /
+          // stores read a different instance than the one valaxy registered,
+          // breaking translations / state. Forcing a single instance avoids that.
+          dedupe: ['vue', 'vue-router', 'vue-i18n', 'pinia'],
         },
 
         optimizeDeps: {

--- a/packages/valaxy/node/plugins/extendConfig.ts
+++ b/packages/valaxy/node/plugins/extendConfig.ts
@@ -133,7 +133,7 @@ export function createConfigPlugin(options: ResolvedValaxyOptions): Plugin {
         define: mergedDefine,
         resolve: {
           alias: await getAlias(options),
-          dedupe: ['vue'],
+          dedupe: ['vue', 'vue-router'],
         },
 
         optimizeDeps: {
@@ -219,6 +219,33 @@ export async function getAlias(options: ResolvedValaxyOptions): Promise<AliasOpt
     alias.push(
       { find: /^vue$/, replacement: await resolveImportPath('vue/dist/vue.esm-bundler.js', true) },
     )
+  }
+
+  // Pin the bare `vue` and `vue-router` specifiers to valaxy's own resolved copy.
+  //
+  // The markdown transform injects `import { provide, shallowRef } from 'vue'`
+  // and `import { useRoute, useRouter } from 'vue-router'` into every user page.
+  // Those imports are resolved relative to the page file under the user's project
+  // root. Under pnpm's default (strict, non-hoisted) layout vue/vue-router are not
+  // surfaced there, so Rolldown may externalize them — leaving a bare
+  // `import … from "vue-router"` in the page chunk that the browser cannot resolve
+  // at runtime ("Failed to resolve module specifier vue-router"). Aliasing to
+  // valaxy's copy makes these imports resolve regardless of the user's package
+  // manager / hoisting, and guarantees a single instance.
+  //
+  // Exact-match regex so subpath imports (`vue-router/vite`, `vue-router/auto-routes`,
+  // `vue-router/experimental`, `vue/server-renderer`, …) keep resolving normally.
+  // `vue` is skipped when `browserTemplateCompilation` already aliased it above.
+  // Resolution is best-effort: if it fails we leave Vite's default resolution untouched.
+  // See: https://github.com/YunYouJun/valaxy/issues/704 (and #701)
+  const vueRouterPath = await resolveImportPath('vue-router')
+  if (vueRouterPath)
+    alias.push({ find: /^vue-router$/, replacement: vueRouterPath })
+
+  if (!options.config.vue?.browserTemplateCompilation) {
+    const vuePath = await resolveImportPath('vue')
+    if (vuePath)
+      alias.push({ find: /^vue$/, replacement: vuePath })
   }
 
   options.addons.forEach((addon) => {

--- a/packages/valaxy/node/plugins/extendConfig.ts
+++ b/packages/valaxy/node/plugins/extendConfig.ts
@@ -221,32 +221,28 @@ export async function getAlias(options: ResolvedValaxyOptions): Promise<AliasOpt
     )
   }
 
-  // Pin the bare `vue` and `vue-router` specifiers to valaxy's own resolved copy.
+  // Pin the bare `vue-router` specifier to valaxy's own copy.
   //
-  // The markdown transform injects `import { provide, shallowRef } from 'vue'`
-  // and `import { useRoute, useRouter } from 'vue-router'` into every user page.
-  // Those imports are resolved relative to the page file under the user's project
-  // root. Under pnpm's default (strict, non-hoisted) layout vue/vue-router are not
-  // surfaced there, so Rolldown may externalize them — leaving a bare
-  // `import … from "vue-router"` in the page chunk that the browser cannot resolve
-  // at runtime ("Failed to resolve module specifier vue-router"). Aliasing to
-  // valaxy's copy makes these imports resolve regardless of the user's package
+  // The markdown transform injects `import { useRoute, useRouter } from 'vue-router'`
+  // into every user page. That import is resolved relative to the page file under
+  // the user's project root. Under pnpm's default (strict, non-hoisted) layout
+  // vue-router is not surfaced there, so Rolldown may externalize it — leaving a
+  // bare `import … from "vue-router"` in the page chunk that the browser cannot
+  // resolve at runtime ("Failed to resolve module specifier vue-router"). Aliasing
+  // to valaxy's copy makes the import resolve regardless of the user's package
   // manager / hoisting, and guarantees a single instance.
   //
+  // Alias to the package *directory* (not a built file) so Vite still applies the
+  // correct browser/node export conditions per build environment — pointing at a
+  // specific build (e.g. `vue-router.node.mjs`) would break client hydration.
   // Exact-match regex so subpath imports (`vue-router/vite`, `vue-router/auto-routes`,
-  // `vue-router/experimental`, `vue/server-renderer`, …) keep resolving normally.
-  // `vue` is skipped when `browserTemplateCompilation` already aliased it above.
+  // `vue-router/experimental`) keep resolving normally.
   // Resolution is best-effort: if it fails we leave Vite's default resolution untouched.
+  // `vue` is intentionally left to Vite's default resolution + `dedupe` below.
   // See: https://github.com/YunYouJun/valaxy/issues/704 (and #701)
-  const vueRouterPath = await resolveImportPath('vue-router')
-  if (vueRouterPath)
-    alias.push({ find: /^vue-router$/, replacement: vueRouterPath })
-
-  if (!options.config.vue?.browserTemplateCompilation) {
-    const vuePath = await resolveImportPath('vue')
-    if (vuePath)
-      alias.push({ find: /^vue$/, replacement: vuePath })
-  }
+  const vueRouterPkg = await resolveImportPath('vue-router/package.json')
+  if (vueRouterPkg)
+    alias.push({ find: /^vue-router$/, replacement: dirname(vueRouterPkg) })
 
   options.addons.forEach((addon) => {
     alias.push({

--- a/packages/valaxy/node/plugins/extendConfig.ts
+++ b/packages/valaxy/node/plugins/extendConfig.ts
@@ -243,7 +243,9 @@ export async function getAlias(options: ResolvedValaxyOptions): Promise<AliasOpt
   // specific build (e.g. `vue-router.node.mjs`) would break client hydration.
   // Exact-match regex so subpath imports (`vue-router/vite`, `vue-router/auto-routes`,
   // `vue-router/experimental`) keep resolving normally.
-  // Resolution is best-effort: if it fails we leave Vite's default resolution untouched.
+  // Resolution is best-effort: if vue-router can't be resolved, `resolveImportPath`
+  // logs a warning and returns undefined, and we skip adding the alias (Vite then
+  // falls back to its default resolution).
   // `vue` is intentionally left to Vite's default resolution + `dedupe` below.
   // See: https://github.com/YunYouJun/valaxy/issues/704 (and #701)
   const vueRouterPkg = await resolveImportPath('vue-router/package.json')

--- a/test/addon.test.ts
+++ b/test/addon.test.ts
@@ -71,3 +71,33 @@ describe('addon alias', () => {
     expect(subpathIdx).toBeLessThan(bareIdx)
   })
 })
+
+describe('vue/vue-router alias', () => {
+  // The markdown transform injects `import { provide, shallowRef } from 'vue'`
+  // and `import { useRoute, useRouter } from 'vue-router'` into every user page.
+  // Pinning the bare specifiers to valaxy's own resolved copy keeps those imports
+  // resolvable regardless of the user's package manager / hoisting layout, avoiding
+  // the runtime "Failed to resolve module specifier vue-router" error.
+  // See: https://github.com/YunYouJun/valaxy/issues/704 (and #701)
+  it('pins bare `vue` and `vue-router` to valaxy\'s resolved copy', async () => {
+    const options = await resolveOptions({ userRoot: fixtureFolder.userRoot })
+    const aliases = await getAlias(options) as Alias[]
+
+    const matchExact = (spec: string) =>
+      aliases.find(a => a.find instanceof RegExp && a.find.source === `^${spec}$`)
+
+    const vueAlias = matchExact('vue')
+    const vueRouterAlias = matchExact('vue-router')
+
+    expect(vueRouterAlias).toBeDefined()
+    expect(vueRouterAlias!.replacement).toContain('vue-router')
+    // exact match only — subpath imports must keep resolving normally
+    expect((vueRouterAlias!.find as RegExp).test('vue-router')).toBe(true)
+    expect((vueRouterAlias!.find as RegExp).test('vue-router/vite')).toBe(false)
+    expect((vueRouterAlias!.find as RegExp).test('vue-router/auto-routes')).toBe(false)
+
+    expect(vueAlias).toBeDefined()
+    expect((vueAlias!.find as RegExp).test('vue')).toBe(true)
+    expect((vueAlias!.find as RegExp).test('vue/server-renderer')).toBe(false)
+  })
+})

--- a/test/addon.test.ts
+++ b/test/addon.test.ts
@@ -1,4 +1,5 @@
 import type { Alias } from 'vite'
+import { isAbsolute } from 'node:path'
 import process from 'node:process'
 import { describe, expect, it } from 'vitest'
 import { resolveOptions } from '../packages/valaxy/node'
@@ -88,6 +89,9 @@ describe('vue-router alias', () => {
     )
 
     expect(vueRouterAlias).toBeDefined()
+    // must be a real resolved absolute path, NOT the bare specifier left unpinned
+    expect(vueRouterAlias!.replacement).not.toBe('vue-router')
+    expect(isAbsolute(vueRouterAlias!.replacement as string)).toBe(true)
     // points at the package directory (not a specific built file like vue-router.node.mjs)
     expect(vueRouterAlias!.replacement).toMatch(/[/\\]vue-router$/)
     // exact match only — subpath imports must keep resolving normally

--- a/test/addon.test.ts
+++ b/test/addon.test.ts
@@ -72,32 +72,27 @@ describe('addon alias', () => {
   })
 })
 
-describe('vue/vue-router alias', () => {
-  // The markdown transform injects `import { provide, shallowRef } from 'vue'`
-  // and `import { useRoute, useRouter } from 'vue-router'` into every user page.
-  // Pinning the bare specifiers to valaxy's own resolved copy keeps those imports
+describe('vue-router alias', () => {
+  // The markdown transform injects `import { useRoute, useRouter } from 'vue-router'`
+  // into every user page. Pinning the bare specifier to valaxy's own copy keeps it
   // resolvable regardless of the user's package manager / hoisting layout, avoiding
-  // the runtime "Failed to resolve module specifier vue-router" error.
+  // the runtime "Failed to resolve module specifier vue-router" error. The alias
+  // targets the package directory so Vite still picks the correct browser/node build.
   // See: https://github.com/YunYouJun/valaxy/issues/704 (and #701)
-  it('pins bare `vue` and `vue-router` to valaxy\'s resolved copy', async () => {
+  it('pins bare `vue-router` to valaxy\'s package directory', async () => {
     const options = await resolveOptions({ userRoot: fixtureFolder.userRoot })
     const aliases = await getAlias(options) as Alias[]
 
-    const matchExact = (spec: string) =>
-      aliases.find(a => a.find instanceof RegExp && a.find.source === `^${spec}$`)
-
-    const vueAlias = matchExact('vue')
-    const vueRouterAlias = matchExact('vue-router')
+    const vueRouterAlias = aliases.find(
+      a => a.find instanceof RegExp && a.find.source === '^vue-router$',
+    )
 
     expect(vueRouterAlias).toBeDefined()
-    expect(vueRouterAlias!.replacement).toContain('vue-router')
+    // points at the package directory (not a specific built file like vue-router.node.mjs)
+    expect(vueRouterAlias!.replacement).toMatch(/[/\\]vue-router$/)
     // exact match only — subpath imports must keep resolving normally
     expect((vueRouterAlias!.find as RegExp).test('vue-router')).toBe(true)
     expect((vueRouterAlias!.find as RegExp).test('vue-router/vite')).toBe(false)
     expect((vueRouterAlias!.find as RegExp).test('vue-router/auto-routes')).toBe(false)
-
-    expect(vueAlias).toBeDefined()
-    expect((vueAlias!.find as RegExp).test('vue')).toBe(true)
-    expect((vueAlias!.find as RegExp).test('vue/server-renderer')).toBe(false)
   })
 })

--- a/test/build/ssg.test.ts
+++ b/test/build/ssg.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from 'vitest'
-import { defaultIncludedRoutes, routesToPaths } from '../../packages/valaxy/node/build/ssg'
+import { defaultIncludedRoutes, getSsgSsrConfig, routesToPaths } from '../../packages/valaxy/node/build/ssg'
+
+describe('getSsgSsrConfig', () => {
+  // Regression guard for https://github.com/YunYouJun/valaxy/issues/704
+  // The built-in SSG server bundle is loaded via native `import()` from a temp
+  // dir. Under pnpm's strict (non-hoisted) layout, externalized transitive deps
+  // (e.g. `@vue/runtime-dom`, `@intlify/core-base`) can't be resolved there and
+  // crash the build with ERR_MODULE_NOT_FOUND. Bundling everything (`noExternal:
+  // true`) keeps the server bundle self-contained. A selective list would
+  // reintroduce the bug, so lock the invariant here.
+  it('bundles all deps into the SSR server build (noExternal: true)', () => {
+    const ssr = getSsgSsrConfig()
+    expect(ssr).toBeDefined()
+    expect(ssr!.noExternal).toBe(true)
+  })
+})
 
 describe('routesToPaths', () => {
   it('returns ["/"] for null/undefined routes', () => {

--- a/test/build/ssg.test.ts
+++ b/test/build/ssg.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it } from 'vitest'
 import { defaultIncludedRoutes, getSsgSsrConfig, routesToPaths } from '../../packages/valaxy/node/build/ssg'
 
 describe('getSsgSsrConfig', () => {
-  // Regression guard for https://github.com/YunYouJun/valaxy/issues/704
+  // Regression guard for the SSG server-bundle ERR_MODULE_NOT_FOUND failure under
+  // pnpm's strict (non-hoisted) layout — the same root cause as, but a distinct
+  // failure mode from, the browser-side bare-import error in #704.
   // The built-in SSG server bundle is loaded via native `import()` from a temp
-  // dir. Under pnpm's strict (non-hoisted) layout, externalized transitive deps
-  // (e.g. `@vue/runtime-dom`, `@intlify/core-base`) can't be resolved there and
-  // crash the build with ERR_MODULE_NOT_FOUND. Bundling everything (`noExternal:
-  // true`) keeps the server bundle self-contained. A selective list would
-  // reintroduce the bug, so lock the invariant here.
+  // dir; externalized transitive deps (e.g. `@vue/runtime-dom`, `@intlify/core-base`)
+  // can't be resolved there. Bundling everything (`noExternal: true`) keeps the
+  // server bundle self-contained. A selective list would reintroduce the bug, so
+  // lock the invariant here.
   it('bundles all deps into the SSR server build (noExternal: true)', () => {
     const ssr = getSsgSsrConfig()
     expect(ssr).toBeDefined()


### PR DESCRIPTION
Fixes #704 and the same-root-cause SSG build failure under pnpm's strict (non-hoisted) `node_modules` layout.

## Changes

### 1. Client: `vue-router` resolution (#704)
The markdown transform injects `import { useRoute, useRouter } from 'vue-router'` into **every user page**, resolved relative to the page file under the user's project root. Under pnpm's strict layout `vue-router` isn't surfaced there, so Rolldown externalizes it — leaving a bare `import … from "vue-router"` in the page chunk that the browser can't resolve at runtime (`Failed to resolve module specifier "vue-router"`).

- `getAlias()` pins bare `vue-router` to valaxy's own copy via `resolve.alias`, targeting the **package directory** (not a built file) so Vite still applies the correct browser/node export conditions per build environment. Exact-match regex keeps subpath imports (`vue-router/vite`, `vue-router/auto-routes`, …) resolving normally.

### 2. SSG: server-bundle resolution under pnpm
`valaxy build --ssg` (default engine) failed with `ERR_MODULE_NOT_FOUND` for deep transitive deps (`@vue/runtime-dom`, `@intlify/core-base`). The built-in SSG engine writes the SSR bundle to `<outDir>/.vite-ssg-temp/entry-ssr.mjs` and loads it via native `import()`; externalized bare imports are then resolved by Node from the temp dir, where pnpm doesn't surface transitive deps.

- Set `ssr.noExternal: true` for the built-in SSG server build (extracted into `getSsgSsrConfig()`), so the server bundle is self-contained. Same pnpm root cause as #704, distinct failure mode. The legacy `vite-ssg` engine (`build.ts`) is intentionally left unchanged.

### 3. Hardening: dedupe shared singletons
valaxy owns the shared singletons (`createApp`/`createRouter`/`createPinia`/`createI18n`) but themes/addons also import them, sometimes undeclared. Added `vue-i18n` and `pinia` to `resolve.dedupe` (alongside `vue`/`vue-router`) to prevent dual-instance bugs (`useI18n()`/stores reading a different instance than valaxy registered). No-op when a single copy exists.

## Tests
- `getAlias` assertions: `vue-router` aliased to an absolute package dir, exact-match only (no subpath capture).
- `getSsgSsrConfig` regression guard: locks `noExternal: true`.

## Verification
- Reconstructed the reporter's pnpm setup (valaxy + theme-yun + addons, no vue/vue-router in user deps); confirmed pnpm does not surface `vue-router` at the project root.
- `valaxy build` and `valaxy build --ssg` (default engine) complete under pnpm with rendered content.
- **Loaded the pnpm-strict SSG build in a real headless browser**: Vue hydrates (`__vue_app__` present), no `Failed to resolve module specifier` / console / page errors.
- Monorepo demo SSG (128 pages) and full unit + E2E suites pass.

## Known limitation (out of scope)
The legacy `vite-ssg` engine (`--ssg-engine vite-ssg`) has a separate `@unhead/vue` SSR head-context integration issue under pnpm (not a duplicate-package/version problem — a single `@unhead/vue` copy is already shared). The default engine is unaffected; tracked separately.

Closes #704