### PR TITLE
fix(cli): keep dev server alive in non-TTY environments

### DIFF
--- a/packages/valaxy/node/cli/dev.ts
+++ b/packages/valaxy/node/cli/dev.ts
@@ -172,8 +172,11 @@ export function registerDevCommand(cli: Argv) {
         bindShortcuts(server, createDevServer)
       }
       await createDevServer()
-      // Keep the process alive — yargs 18 exits after async handlers resolve
-      await new Promise(() => {})
+
+      // Block forever so the command handler never settles (yargs 18 force-exits once it
+      // does). The vite dev server keeps the event loop alive and installs its own
+      // SIGTERM/stdin-`end` shutdown handlers, so we don't add our own here.
+      await new Promise<never>(() => {})
     },
   )
 }

--- a/packages/valaxy/node/cli/utils/shortcuts.ts
+++ b/packages/valaxy/node/cli/utils/shortcuts.ts
@@ -67,16 +67,19 @@ export const SHORTCUTS: CLIShortcut[] = [
  * bind shortcut for terminal
  */
 export function bindShortcuts(server: ViteDevServer, createDevServer: CreateDevServer) {
-  if (!server.httpServer || process.env.CI) {
-    console.log('restart server to enable shortcuts', server.httpServer, process.stdin.isTTY, process.env.CI)
+  // Shortcuts require a raw-mode TTY, so skip non-interactive environments
+  // (CI, piped stdin, docker without `-it`, pm2/nohup, background jobs).
+  // Beyond being useless there, `process.stdin.resume()` on a non-TTY stdin puts it into
+  // flowing mode and lets it reach EOF — which triggers vite's `process.stdin.on('end')`
+  // handler (registered in `server.listen()` unless `CI==='true'`) to close the server and
+  // exit. That is what made `valaxy dev` exit immediately in non-TTY environments.
+  if (!server.httpServer || !process.stdin.isTTY || process.env.CI)
     return
-  }
 
   process.stdin.resume()
   process.stdin.setEncoding('utf8')
   readline.emitKeypressEvents(process.stdin)
-  if (process.stdin.isTTY)
-    process.stdin.setRawMode(true)
+  process.stdin.setRawMode(true)
 
   async function onKeyPress(str: any, key: any) {
     if (key.ctrl && key.name === 'c') {


### PR DESCRIPTION
## Problem

`valaxy dev` exits immediately after startup whenever **stdin is not a TTY** — CI without `CI=true`, piped stdin, `docker` without `-it`, `pm2`/`nohup`, or background jobs. It prints the preview URL and then the process just goes away without ever serving a request.

Reproduced deterministically against [Big-Cake-jpg/big-cake-jpg.github.io](https://github.com/Big-Cake-jpg/big-cake-jpg.github.io) (latest valaxy `0.28.10`) with a closed stdin (`pnpm dev </dev/null`):

| Build | Survived | Served `/` |
| --- | --- | --- |
| published `0.28.10` | **0 / 6** | 0 / 6 |
| this PR | **8 / 8** | 8 / 8 |

## Root cause

On `server.listen()`, **vite registers `process.stdin.on('end', …)`** (unless `process.env.CI === 'true'`) that closes the server and exits the process — a deliberate "shut down when the controlling pipe closes" behavior:

```js
// vite/dist/node/chunks/node.js
const setupSIGTERMListener = (callback) => {
  if (sigtermCallbacks.size === 0) {
    process.once('SIGTERM', parentSigtermCallback)
    if (process.env.CI !== 'true') process.stdin.on('end', parentSigtermCallback) // closeServerAndExit
  }
  ...
}
```

`bindShortcuts()` called `process.stdin.resume()` **unconditionally**. On a non-TTY stdin that puts it into flowing mode, it reaches EOF, fires vite's `end` handler, and tears the dev server down → process exits.

## Fix

- **`shortcuts.ts`**: skip shortcut binding entirely when `process.stdin` is not a TTY. Shortcuts need raw-mode keypresses and can never work there anyway, so stdin is left untouched and vite's `end` shutdown is never triggered. Also removes the leftover debug `console.log` and the now-redundant inner `isTTY` check.
- **`dev.ts`**: keep the minimal `await new Promise<never>(() => {})` block (with a clarifying comment). No custom signal handlers — vite continues to own SIGTERM/stdin-`end` shutdown (graceful `server.close()` + exit).

No behavior change in a real terminal — interactive `r/o/q/e` shortcuts still work, and Ctrl+C / SIGTERM still quit.

## Verification

- ✅ deterministic survival test above (published 0/6 → this PR 8/8), zero `dep-scan`/`server closed` noise after the fix
- ✅ `SIGTERM` → graceful shutdown via vite (`server.close()` then exit)
- ✅ ESLint: 0 errors on changed files
- ✅ `vue-tsc --noEmit --skipLibCheck`: 0 errors
- ✅ codebase swept: `bindShortcuts` is the only `stdin.resume()` caller; no other long-running command has this pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)