### PR TITLE
chore(deps)!: bump unocss & unplugin-vue-markdown for Vite 8; require Node >=22.12

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,7 @@ The dev server supports hot reload for:
 - Styles
 
 ### Node Version
-Requires Node.js 18+ or 20+
+Requires Node.js >= 22.12 (Vite 8 + unplugin-vue-markdown@32; Node 18/20 dropped in v1.0)
 
 ## Testing Strategy
 

--- a/docs/pages/guide/deploy.md
+++ b/docs/pages/guide/deploy.md
@@ -180,7 +180,7 @@ Refer to the Nginx section for the `nginx.conf` configuration and place it in th
 ::: details Dockerfile
 
 ```Dockerfile [Dockerfile]
-FROM node:20-alpine as build-stage
+FROM node:22-alpine as build-stage
 
 WORKDIR /app
 RUN corepack enable

--- a/docs/pages/guide/deploy.md
+++ b/docs/pages/guide/deploy.md
@@ -180,7 +180,7 @@ Refer to the Nginx section for the `nginx.conf` configuration and place it in th
 ::: details Dockerfile
 
 ```Dockerfile [Dockerfile]
-FROM node:22-alpine as build-stage
+FROM node:22.12-alpine as build-stage
 
 WORKDIR /app
 RUN corepack enable

--- a/docs/pages/guide/getting-started.md
+++ b/docs/pages/guide/getting-started.md
@@ -43,7 +43,7 @@ You can use [StackBlitz](https://stackblitz.com/edit/valaxy) to try Valaxy onlin
 
 ::: danger Compatibility Note
 
-Vite@7 requires [Node.js](https://nodejs.org/en/) version `^20.19.0 || >=22.12.0`. Valaxy also requires you to upgrade Node.js after version `20.19.0`.
+Valaxy requires [Node.js](https://nodejs.org/en/) version `>=22.12.0` (Vite 8 and `unplugin-vue-markdown@32` no longer support Node 18/20). Please upgrade Node.js to `22.12.0` or later.
 
 :::
 

--- a/docs/pages/guide/getting-started.md
+++ b/docs/pages/guide/getting-started.md
@@ -43,7 +43,7 @@ You can use [StackBlitz](https://stackblitz.com/edit/valaxy) to try Valaxy onlin
 
 ::: danger Compatibility Note
 
-Valaxy requires [Node.js](https://nodejs.org/en/) version `>=22.12.0` (Vite 8 and `unplugin-vue-markdown@32` no longer support Node 18/20). Please upgrade Node.js to `22.12.0` or later.
+Valaxy requires [Node.js](https://nodejs.org/en/) `>=22.12.0`. This comes from `unplugin-vue-markdown@32` (which requires Node `>=22`) combined with Vite 8 (which requires `^20.19.0 || >=22.12.0`) — so on the Node 22 line the minimum is `22.12.0`. Please upgrade Node.js to `22.12.0` or later.
 
 :::
 

--- a/docs/pages/zh/guide/deploy.md
+++ b/docs/pages/zh/guide/deploy.md
@@ -197,7 +197,7 @@ server {
 ::: details Dockerfile
 
 ```Dockerfile [Dockerfile]
-FROM node:20-alpine as build-stage
+FROM node:22-alpine as build-stage
 
 WORKDIR /app
 RUN corepack enable

--- a/docs/pages/zh/guide/deploy.md
+++ b/docs/pages/zh/guide/deploy.md
@@ -197,7 +197,7 @@ server {
 ::: details Dockerfile
 
 ```Dockerfile [Dockerfile]
-FROM node:22-alpine as build-stage
+FROM node:22.12-alpine as build-stage
 
 WORKDIR /app
 RUN corepack enable

--- a/docs/pages/zh/guide/getting-started.md
+++ b/docs/pages/zh/guide/getting-started.md
@@ -49,7 +49,7 @@ top: 100
 
 ::: danger 兼容
 
-由于 Vite@7 要求 [Node.js](https://nodejs.org/en/) 的版本为 `^20.19.0 || >=22.12.0`，Valaxy 同样需要你将 Node.js 升级至 `20.19.0` 版本之后。
+由于 Vite 8 与 `unplugin-vue-markdown@32` 不再支持 Node 18/20，Valaxy 要求 [Node.js](https://nodejs.org/en/) 的版本为 `>=22.12.0`，请将 Node.js 升级至 `22.12.0` 或更高版本。
 
 :::
 

--- a/docs/pages/zh/guide/getting-started.md
+++ b/docs/pages/zh/guide/getting-started.md
@@ -49,7 +49,7 @@ top: 100
 
 ::: danger 兼容
 
-由于 Vite 8 与 `unplugin-vue-markdown@32` 不再支持 Node 18/20，Valaxy 要求 [Node.js](https://nodejs.org/en/) 的版本为 `>=22.12.0`，请将 Node.js 升级至 `22.12.0` 或更高版本。
+Valaxy 要求 [Node.js](https://nodejs.org/en/) 的版本为 `>=22.12.0`。这是由 `unplugin-vue-markdown@32`（要求 Node `>=22`）与 Vite 8（要求 `^20.19.0 || >=22.12.0`）共同决定的——在 Node 22 分支上最低需要 `22.12.0`。请将 Node.js 升级至 `22.12.0` 或更高版本。
 
 :::
 

--- a/e2e/docs/search.spec.ts
+++ b/e2e/docs/search.spec.ts
@@ -15,9 +15,10 @@ test.describe('docs search', () => {
         warnings.push(msg.text())
     })
 
-    await page.goto('/', { waitUntil: 'networkidle' })
-    // Ensure the Vue app has mounted (async mount chain in main.ts can finish
-    // after networkidle), so the search component's listeners are registered.
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    // Ensure the Vue app has mounted (the async mount chain in main.ts is the
+    // real readiness signal, not the network going idle), so the search
+    // component's listeners are registered. See e2e/utils/hydration.ts.
     await waitForHydration(page)
 
     // Search button should be visible
@@ -42,7 +43,7 @@ test.describe('docs search', () => {
   })
 
   test('Cmd/Ctrl+K opens search', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'networkidle' })
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
     // The Cmd/Ctrl+K handler is an `onKeyStroke` registered during the search
     // component's setup, which only runs after `app.mount()`. Wait for the app
     // to finish mounting/hydrating before pressing, otherwise the keystroke is

--- a/e2e/utils/hydration.ts
+++ b/e2e/utils/hydration.ts
@@ -3,19 +3,27 @@ import type { Page } from '@playwright/test'
 /**
  * Wait until the Valaxy Vue app has finished mounting / hydrating.
  *
- * `page.goto(..., { waitUntil: 'networkidle' })` is NOT enough: the client
- * mount in `packages/valaxy/client/main.ts` is gated behind an async chain
- * (`await import('@unhead/vue/client')` + `await router.isReady()`) before
- * `app.mount('#app')` runs. With cached chunks there can be zero network
- * requests, so `networkidle` may fire BEFORE that async mount resolves —
- * meaning component `setup()` (and any window-level listeners they register,
- * e.g. the Cmd/Ctrl+K `onKeyStroke` in `PressNavBarSearch.vue`) is not yet
- * attached.
+ * Prefer `page.goto(url, { waitUntil: 'domcontentloaded' })` followed by
+ * `waitForHydration(page)` over `waitUntil: 'networkidle'`:
+ *
+ * 1. `networkidle` is unreliable for *readiness*. The client mount in
+ *    `packages/valaxy/client/main.ts` is gated behind an async chain
+ *    (`await import('@unhead/vue/client')` + `await router.isReady()`) before
+ *    `app.mount('#app')` runs. With cached chunks there can be zero network
+ *    requests, so `networkidle` may fire BEFORE that async mount resolves —
+ *    meaning component `setup()` (and any window-level listeners they register,
+ *    e.g. the Cmd/Ctrl+K `onKeyStroke` in `PressNavBarSearch.vue`) is not yet
+ *    attached.
+ * 2. `networkidle` is also *flaky*: against the Vite dev server, background
+ *    activity (HMR, UnoCSS dev updates, the git-log addon's API calls, async
+ *    DocSearch chunks) can keep the network busy so it never idles for 500ms,
+ *    making `page.goto` itself time out. This is a documented Playwright
+ *    anti-pattern.
  *
  * Vue's runtime-dom sets the `data-v-app` attribute on the mount container
  * synchronously right after `app.mount()` returns (for both client render and
  * hydration). Waiting for it is a deterministic "app is interactive" signal —
- * no arbitrary timeouts.
+ * no arbitrary timeouts, no dependence on the network ever going quiet.
  */
 export async function waitForHydration(page: Page, selector = '#app'): Promise<void> {
   await page.locator(`${selector}[data-v-app]`).waitFor({ state: 'attached' })

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "blog"
   ],
   "engines": {
-    "node": "^18.0.0 || >=20.0.0"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "api:dev": "pnpm -C api run dev",

--- a/packages/create-valaxy/package.json
+++ b/packages/create-valaxy/package.json
@@ -31,7 +31,7 @@
     "template-*/**/*"
   ],
   "engines": {
-    "node": "^18.0.0 || >=20.0.0"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -60,12 +60,19 @@
     "@types/splitpanes": "catalog:",
     "@types/wicg-file-system-access": "catalog:",
     "@unocss/reset": "catalog:",
+    "@vitejs/plugin-vue": "catalog:",
     "gray-matter": "catalog:",
+    "pinia": "catalog:",
     "reka-ui": "catalog:frontend",
     "splitpanes": "catalog:",
     "typescript": "catalog:build",
     "unbuild": "catalog:build",
+    "unocss": "catalog:",
+    "unplugin-vue-components": "catalog:",
     "vite": "catalog:build",
-    "vue-i18n": "catalog:build"
+    "vite-plugin-vue-devtools": "catalog:",
+    "vue": "catalog:frontend",
+    "vue-i18n": "catalog:build",
+    "vue-router": "catalog:"
   }
 }

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -59,6 +59,7 @@
     "@types/body-parser": "catalog:",
     "@types/splitpanes": "catalog:",
     "@types/wicg-file-system-access": "catalog:",
+    "@unocss/reset": "catalog:",
     "gray-matter": "catalog:",
     "reka-ui": "catalog:frontend",
     "splitpanes": "catalog:",

--- a/packages/valaxy/package.json
+++ b/packages/valaxy/package.json
@@ -57,7 +57,7 @@
     "types"
   ],
   "engines": {
-    "node": "^18.0.0 || >=20.0.0"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ catalogs:
     '@types/yargs':
       specifier: ^17.0.35
       version: 17.0.35
+    '@unocss/reset':
+      specifier: 66.7.2
+      version: 66.7.2
     '@vitejs/plugin-vue':
       specifier: ^6.0.6
       version: 6.0.6
@@ -461,14 +464,14 @@ catalogs:
       specifier: ^1.1.2
       version: 1.1.2
     unocss:
-      specifier: 66.5.10
-      version: 66.5.10
+      specifier: 66.7.2
+      version: 66.7.2
     unplugin-vue-components:
       specifier: 28.0.0
       version: 28.0.0
     unplugin-vue-markdown:
-      specifier: ^30.0.0
-      version: 30.0.0
+      specifier: ^32.0.0
+      version: 32.0.0
     valaxy-addon-artalk:
       specifier: ^0.1.3
       version: 0.1.3
@@ -838,6 +841,9 @@ importers:
       '@types/wicg-file-system-access':
         specifier: 'catalog:'
         version: 2023.10.7
+      '@unocss/reset':
+        specifier: 'catalog:'
+        version: 66.7.2
       gray-matter:
         specifier: 'catalog:'
         version: 4.0.3
@@ -1062,13 +1068,13 @@ importers:
         version: 2.1.13
       unocss:
         specifier: 'catalog:'
-        version: 66.5.10(postcss@8.5.14)(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        version: 66.7.2(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       unplugin-vue-components:
         specifier: 'catalog:'
         version: 28.0.0(@babel/parser@7.29.0)(@nuxt/kit@3.21.0(magicast@0.5.2))(rollup@4.57.1)(vue@3.5.22(typescript@5.9.3))
       unplugin-vue-markdown:
         specifier: 'catalog:'
-        version: 30.0.0(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+        version: 32.0.0(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
       vanilla-lazyload:
         specifier: 'catalog:'
         version: 19.1.3
@@ -1487,11 +1493,6 @@ packages:
     resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.27.7':
-    resolution: {integrity: sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.29.0':
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
@@ -1545,10 +1546,6 @@ packages:
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.27.7':
-    resolution: {integrity: sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.0':
@@ -2158,6 +2155,9 @@ packages:
   '@iconify/utils@3.1.0':
     resolution: {integrity: sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==}
 
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
+
   '@internationalized/date@3.11.0':
     resolution: {integrity: sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q==}
 
@@ -2536,8 +2536,138 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxc-parser/binding-android-arm-eabi@0.131.0':
+    resolution: {integrity: sha512-t2xicr9pfzkSRYx5aPqZqlLaayIwJTqgQ81Jor31Xep2nGyL2Aq3d0K5wOfeR7VevaSdxaS9dzSQP9xDwn8fDg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.131.0':
+    resolution: {integrity: sha512-nlGIod6gw75x1aEDgLS+srj+JRGY0HHm9MI9YgzE/B64l6d6+H3MSP9NOgp0+HTg8tp4vV9rVfgQGgd+TfVZcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.131.0':
+    resolution: {integrity: sha512-jukuV6xe5RbQKFo7QD34NDCLDZp4PSOm8rmckhNdH/60ymG5zXbDzGBEyc+nTkuLQNama2aSGCt+CPfpjNTqyw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.131.0':
+    resolution: {integrity: sha512-g3JOo4khe9rslHm5WYaVDWb0HS/M1MLR3I9S8560MkKIcC96VQY00QjOlsuRyfSj/JDXj8i9T7ryPO2RidiXVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.131.0':
+    resolution: {integrity: sha512-1hziITDTxjMePnX+dR9ocVT+EuZkQ8wm4FPAbmbEiKG+Phbo73J1ZnPAA6Y/aGsWF3McOFnQuZIktAFwalkfJQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.131.0':
+    resolution: {integrity: sha512-9uRxfXwyKG9+MwmGQBo2ncPNwZH5HTmCETFM2WiuDBNDCW4NC5ttSQkwCAMrTAWgwMzVBH1CP8pM0v7nebCWXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.131.0':
+    resolution: {integrity: sha512-mgbLvzRShXOLBdWGInf08Af4q+pfj1xD8hSgLClDZ9of/BXkB6+LIhTH7fihiDUipqB3yoSkKBWaZ3Ejlf5Yag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.131.0':
+    resolution: {integrity: sha512-OPT8++4aN6j2GJ8+3IZHS/byXoZP4aSBn+FoG6rgBJ2fKwPKXWF3MqrFMNW7NKHM28FLY579xYLxJSfgobEqPA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.131.0':
+    resolution: {integrity: sha512-vtPiwmfVTAXzaxDKsOXG+LwgRAA7WEnaeHzhS5z0GE89gAK18KSXnly7Z6saXXq6L3dVMyK44uoTI03zKxrpmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.131.0':
+    resolution: {integrity: sha512-8AW8L7w5cGHSdZPcyZX2yR0+GUODsT15rbRjfdD54rv6DMbtuEB19ysLOpKJlRGfH6UNYNpCHaU1uJWgTWf1/w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.131.0':
+    resolution: {integrity: sha512-vvpjkjEOUsPcsYf8evE4MO3aGx9+3wodXEBOicGNnOwTuAik8eBONNkgSdhkGsAblQmfVHJyanRnpxglddTXIA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.131.0':
+    resolution: {integrity: sha512-AqmcNC3fClXX+fxQ6VGEN1667xVFiRBkY0CZmDMSiaeFUsv1+UkBPYYi48IUKcA9/ivvoKNRzQl2I4//kT9F/w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.131.0':
+    resolution: {integrity: sha512-7d3jOMKy7RSQCcDLIci+ySll2FgsOMl/GiRux4q2JNv0zg4EdhFISa9idvrdN/HEUIQQJNg6dmveUeJl2YErGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.131.0':
+    resolution: {integrity: sha512-JHK/h95qVqVQ+ITER837kcTdwBDFpFaNnOTYGCP0zdUSX/mLKC7tXOoyrTb6vG7iRPwGlcgBil3v2IjYw1FqJA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.131.0':
+    resolution: {integrity: sha512-b2BO82O8azXAyf7EUgOPKu145nWypbNyk07HbU09fkzhm9lEA5oPvaN/M8Nlo7tOErVTa2WOgS4QbOnxAPXdDQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.131.0':
+    resolution: {integrity: sha512-GHO9glZaX7LkX/OGfluEPf1yjg+ehiFbUdowbX6uNWOQhmwKWU4m4+nZ9FJkrHNKuxyI1KKertMdGjVKCApKWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.131.0':
+    resolution: {integrity: sha512-3SkikPaEFoih1N83qLVEDLRLeY4nYsf6JT9SnWiMCQ5lGQdKup6bEuKCqkRiG9dD1IIaFeYz9RjlciPmYoFIWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.131.0':
+    resolution: {integrity: sha512-Os5bEhryeA2jkH+ZrnZyAC1EP5gs+X4YB1Fjqml7UPD5kU7ecsK1MPEVMfCrdt/GDNpDbavYXiOXOdyJ5b3OPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.131.0':
+    resolution: {integrity: sha512-m+jNz9EuF0NXoiptc6B9h5yompZQVW/a5MJeOu5zojfH5yWk82tvF2ccrHkfhgtrS9h9DD5l1Qv8dWlfY7Nz8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.131.0':
+    resolution: {integrity: sha512-o14Hk8dAyiEUMFEWEgmAwFZvBt1RzAYLM3xeQ+5315JXgVYhoemivgYcbYVRbsFkS71ShMGlAFE0kPnr460rww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@oxc-project/types@0.128.0':
     resolution: {integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==}
+
+  '@oxc-project/types@0.131.0':
+    resolution: {integrity: sha512-PgnWDfV0h+b16XNKbXU7Daib/BFSt/J2mEzfYIBu6JB/wNdlU+kVYXCkGA1A9fWkTbOgbjh4e6NhPeQOYvFhEA==}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -3524,89 +3654,72 @@ packages:
     peerDependencies:
       vue: 3.5.22
 
-  '@unocss/astro@66.5.10':
-    resolution: {integrity: sha512-R1UU8lfIqcuorGpiuU+9pQEmK8uBBk1sf5re1db9kr23924Ia/aBCmfs4W2xyVCwJ0cGBv9C3ywDgOsgkHFCbQ==}
-    peerDependencies:
-      vite: ^8.0.11
-    peerDependenciesMeta:
-      vite:
-        optional: true
-
-  '@unocss/cli@66.5.10':
-    resolution: {integrity: sha512-3tGBTGLLTtwGEwXGWsL77K4bTvNG115VJvYPPit68Z7uXnA6S8xpkwaFFDJ3kbrsWtgXBpIgM06HhtT6/3MILg==}
-    engines: {node: '>=14'}
+  '@unocss/cli@66.7.2':
+    resolution: {integrity: sha512-50vBptZyiyYzm5CBNSVs1WYIFX+7IKYFwLNrm6pVCOjHfrBmmpfvyCznPMzUcGEFKvP2VsyB2hf3k57GBCSS9Q==}
     hasBin: true
 
-  '@unocss/config@66.5.10':
-    resolution: {integrity: sha512-udBhfMe+2MU70ZdjnRLnwLQ+0EHYJ4f5JjjvHsfmQ0If4KeYmSStWBuX+/LHNQidhl487JiwW1lBDQ8pKHmbiw==}
-    engines: {node: '>=14'}
+  '@unocss/config@66.7.2':
+    resolution: {integrity: sha512-m8LZUZOFHBesViFOnC1MzMMQ1ovYbZ/F2ntkKSIWzLO/VvEYo2/HK8qhBhtI/FyL27+gvePL4sZ6a5ZChyl0Ug==}
 
-  '@unocss/core@66.5.10':
-    resolution: {integrity: sha512-SEmPE4pWNn9VcCvZqovPwFGuG/j69W3zh+x1Ky4z/I2pnyoB0Y0lBmq22KVu/dwExe+ZKKTQpxa0j5rbE27rDQ==}
+  '@unocss/core@66.7.2':
+    resolution: {integrity: sha512-NNnhm9IVPEZ34drwztREP+mq1rio0L4Tp0u247qBKxJJWYec1+I+FTRsw7EvtukZKvr56YAxFA1qbBV+LjyV+Q==}
 
-  '@unocss/extractor-arbitrary-variants@66.5.10':
-    resolution: {integrity: sha512-9JsAY1a68WZaIbSiwQa7LLAO+t4T5nnhgmNxY3MGaK58k6Qa9ayZb4AG4fqOpw+Zn8tmKd7yXJ0s+27sx1n2BA==}
+  '@unocss/extractor-arbitrary-variants@66.7.2':
+    resolution: {integrity: sha512-1R+ntws4zhi9gCsyovYeNCiAYGSceN6Rsy/4kyaw3npr1UBWhBJdQZtacxvqOssPfbbqq2vpatcuQ4rfZZYWFQ==}
 
-  '@unocss/inspector@66.5.10':
-    resolution: {integrity: sha512-L/Nvi4bkXFxbGNOi7TPNnIIDfY1zKghfJ+cF7To/WrXplP1Y4nEZa2kGwcVBcsaysACri0whU19Dh3yf+bG+Pg==}
+  '@unocss/inspector@66.7.2':
+    resolution: {integrity: sha512-fvZ8w9dTnu61ZwbXjVMQopxxrQOnFOBN2I6KVPJtoUSMsatrpEYyJHDA9pfLes1a3C4eEJZaSADURHKkON09CA==}
 
-  '@unocss/postcss@66.5.10':
-    resolution: {integrity: sha512-Hp9k+1AB0qxc6b7Sh7JPKwYgcklIvRhleYtQldFbdU5eAY5InOy9m7gSZxRsz2WQb6IzliqO7Or34PbhnMlcFQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      postcss: ^8.4.21
+  '@unocss/preset-attributify@66.7.2':
+    resolution: {integrity: sha512-JnnoRUgOL4O565+jNi8BfzTQDElEny1reaMhrdYQR4P4I7cfdRV89R5DsmND0H2mGtwJjP/gL4cWd1FSX9ShrA==}
 
-  '@unocss/preset-attributify@66.5.10':
-    resolution: {integrity: sha512-dEFs8kXC9xoqolQBFvtgXvdzWQqHoWqSj/eosX2oDmy8REk7UErpBvMmqR4pCP7mqdtG8yZ2l34Gtb42hDM3JA==}
+  '@unocss/preset-icons@66.7.2':
+    resolution: {integrity: sha512-C05oM7j8jFuxjbPaRFUbcwxHPXvBtmJOhaE2M3YstVR/L9IBsQ6Ts/PT1vxVAVDmX19MudRRTnQ0x5XzUM3P7A==}
 
-  '@unocss/preset-icons@66.5.10':
-    resolution: {integrity: sha512-zf4Sev/F2QQgVjGjKBCw3BKc15HQAtvUrNX2zymXXbAjt83Lf27ofYzTAUVUO9mi/oQhXcP5sQrIGIe7iQX3hw==}
+  '@unocss/preset-mini@66.7.2':
+    resolution: {integrity: sha512-2DLS20vj+eoZI/r7U8eTxd+HTfMYamhx03mJyeadNu+efVJZrfEEMwjILgFywVAthYINmdeB4sYpc8Qfef4Vww==}
 
-  '@unocss/preset-mini@66.5.10':
-    resolution: {integrity: sha512-jRmweaPhaTGBSDKFuhEGayGyuGr66rTRRqzv5EAdHH4x43TFlJ1RO5SVlzzJdo1zJy4vyGSINIVKeI49FYhEKQ==}
+  '@unocss/preset-tagify@66.7.2':
+    resolution: {integrity: sha512-46V3ibNqKEyeSNnplsOKiYiBdNZ348JgjhnGDWHigVYIfZkEqn6WJdGAX9tVZpjI/rS9px8jQA0lm6ubKoc8iQ==}
 
-  '@unocss/preset-tagify@66.5.10':
-    resolution: {integrity: sha512-SLfMhNQCFEXspp/zREZv61dmuvRQ+CVI04zcpGpg4LnqvMKkLVyPPetlhgJwW1hd9D7OWkUGoQm9JA0O4+9XJA==}
+  '@unocss/preset-typography@66.7.2':
+    resolution: {integrity: sha512-6nTRoZiHTkDV87omRlEn8RZhakMYrIJtzazfj0rdF8msvjM1LnTT6K6qDlmxqb6NBIakljNb0bryubr6bWzK9A==}
 
-  '@unocss/preset-typography@66.5.10':
-    resolution: {integrity: sha512-GMchTwywSA6vwiZ2w8svBY9U9br/OW7vIjwyYis0c9kp4h8apKCrLtAv2LjmlKyg12IDy9d8jp/hZ1zP9umung==}
+  '@unocss/preset-uno@66.7.2':
+    resolution: {integrity: sha512-XiSGtnh04sGHCRUnlxhePBhRF8zfOQlCfYkKByQcp/pvhmFMIWwzVL68R5LwxBmBwBVY4hfQAIx0Sz/FbA3Ojg==}
 
-  '@unocss/preset-uno@66.5.10':
-    resolution: {integrity: sha512-O3R99td+Jt3XAJh1pVbOSTu3z7jUosg80y90iu6JQIpvXI/pGanWJEhoEz95SgJmRV+vXNEn4f6tIvfUXkTd/w==}
+  '@unocss/preset-web-fonts@66.7.2':
+    resolution: {integrity: sha512-Tx6YJWxD29NoG6t8hpbnectdL8KkBVEzEYwBcJlEa200O6/KXNpGJ8tk4l5+EK1dwTxWkUqsG+60fzXzTpe5Gg==}
 
-  '@unocss/preset-web-fonts@66.5.10':
-    resolution: {integrity: sha512-rA9pjL+CuDpyEekawX54pkWHc4n+kfhoYsAFBWBtNHl4akDYsbnSA+2EF/XiEbRvz1YVFYDucZ9KpUiaq9+xtQ==}
+  '@unocss/preset-wind3@66.7.2':
+    resolution: {integrity: sha512-3WUmNZ3ibNotel6PAm1AgdK8BP2RqThRvEYU+svZgxsCX8E/RtVM68BFPOwzsEtuMD/R3Up6rHXqZsJvUQsg+A==}
 
-  '@unocss/preset-wind3@66.5.10':
-    resolution: {integrity: sha512-N2Wgu+AnTSr4jIEAfajOfUtwESE/Zzr0GxwW88+MHIw6Tzj6tZeCEKNNKFzsgwfGkoNjvwIeIbkaIrIGJ7SveA==}
+  '@unocss/preset-wind4@66.7.2':
+    resolution: {integrity: sha512-yP1Np15QKm+zh945lBmpNC2FnD4oyd0eq9qA6j8r15uvhz7AF98t9dGqqzV5WrjX+IZpwg08nP3son1IjAerLw==}
 
-  '@unocss/preset-wind4@66.5.10':
-    resolution: {integrity: sha512-PXLxEcYJUsysQvK4xj3iA7plvq5RcAt9S1vLlOmBtl2X66dWU6XqiGEu7lLfqoypip1bPCOGlRB7HbfMuQpftQ==}
+  '@unocss/preset-wind@66.7.2':
+    resolution: {integrity: sha512-porNxph4xfr67e0LpFis813rKk9+psUJMw0nPL4sZoHovhmR/hA5XlWb6fLCl7t4Lls20I/n8F8KKgkqkxnk8Q==}
 
-  '@unocss/preset-wind@66.5.10':
-    resolution: {integrity: sha512-tR8JaXHnL006qcIEbD4lalZoqvW78SE+OvD7Sv5yj6s5FjwLZTiaJP8/0RTlx8SvhM6bw+NDxKQq678ntiZdiA==}
+  '@unocss/reset@66.7.2':
+    resolution: {integrity: sha512-dKRbpBicfchatvqK2wqfX8gtNTCf+2pFdXBNDC0Cl2PZ8QCVMtCaHTOTSyruM0Pw7aqST4SlPkF5f8x7aZZL0w==}
 
-  '@unocss/reset@66.5.10':
-    resolution: {integrity: sha512-xlydsCqbmVtA8QbVWv8+R66v4MJzeDXYsdoGDz7xsa2r65RD4UvJFZuyueY7+/bhzns9QhNOxltEiPi06j3Gvw==}
+  '@unocss/rule-utils@66.7.2':
+    resolution: {integrity: sha512-EGi2m9I87hluz2zgjVpXM4PWFn996RInNcx4PGF6Qw9Z0W78ROXEto0SM1IltpJ4R7+at4EhssU0IbHiT0snEw==}
 
-  '@unocss/rule-utils@66.5.10':
-    resolution: {integrity: sha512-497GPWZpArNG25cto0Yq3/Yw+i0x7/N/ySq1HHeE3lB43sdmCv6+m6QEv14I/9/e5WJhQOmrY5LmHZYXC7xxMw==}
-    engines: {node: '>=14'}
+  '@unocss/transformer-attributify-jsx@66.7.2':
+    resolution: {integrity: sha512-lb5y4lwHCjZm+9L3k6c/fq9O75+mQcxBp2Dq+a3DS+vOQpPce+hOyLFFkiHVRNKp9chEHS9gnq58SBVxJbhR2A==}
 
-  '@unocss/transformer-attributify-jsx@66.5.10':
-    resolution: {integrity: sha512-WAAVWWx/BVQ9dk1W9FCP7UL9dLScmNDrRwBRah5WJMtKaV890RaL4wLItfQH0SN31C+quTwuaU0Hi6BiBsc9qw==}
+  '@unocss/transformer-compile-class@66.7.2':
+    resolution: {integrity: sha512-/vdgxgUI9vp7NOGfuOCY44/Ja2YbR0m+sWCGHq8K8/53a3Dk+4AvXPePv/EI/Oo6z8bhSGZHCSes8pBEY8Mr8A==}
 
-  '@unocss/transformer-compile-class@66.5.10':
-    resolution: {integrity: sha512-NFXf5qTVJXZNnZTpnCSQmNwJhQrmCQv/tgmX69rwNDYKmYcBufpaKfwKzO+EkVQz4A6ySv09Q9PaNBCH5N0FTQ==}
+  '@unocss/transformer-directives@66.7.2':
+    resolution: {integrity: sha512-9xr5Tiy+urutRBcyKJUAOOpW3LSuSM59sKowdTStzZdBUMs/L9cmjfsjNFt8rm5tptUR25wGZ8xLR5hhVDAiBQ==}
 
-  '@unocss/transformer-directives@66.5.10':
-    resolution: {integrity: sha512-EDak3DGW+rSYjoZNwU8xJIXbwif+q9e3cjhCZy48ll1nfyg2E1Znqtwv/X8vLRr8fJ0gWn75P2uGi4jfGLZzMg==}
+  '@unocss/transformer-variant-group@66.7.2':
+    resolution: {integrity: sha512-CO0CoYRn96wLm+cIICuNrv96cfzEkBHc/OmTYcHzlheyZRfGWPWlPpazMr2rlm5bve986akAxe2HSBqdaRf04w==}
 
-  '@unocss/transformer-variant-group@66.5.10':
-    resolution: {integrity: sha512-9DWi9bLOGwdw6whCTdywVD9+lA5lkeqcgy9sMoizfUa4CfT1bSdMT27VoAbYhxeEznV92BCW2jCYt0I8M00phw==}
-
-  '@unocss/vite@66.5.10':
-    resolution: {integrity: sha512-GegFDmcWe0V2CR/uN1f+iQuDh2R1vA6EAwSvl1nyL+6ue0/zLyF9yhdVnypIVlJnS6RK/xaLPOP6vWJnqRGhZg==}
+  '@unocss/vite@66.7.2':
+    resolution: {integrity: sha512-KZL8LFNcoOjAaF8AKSUJznxrjcmuQKPSAmwvndL5RjEWtbyunV66YvOuoBPN3F0tR7MhY5NWKJjwmaYyetcM1Q==}
     peerDependencies:
       vite: ^8.0.11
 
@@ -5509,10 +5622,6 @@ packages:
     resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
     engines: {node: '>=6'}
 
-  globals@11.12.0:
-    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
-    engines: {node: '>=4'}
-
   globals@15.15.0:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
@@ -6267,6 +6376,9 @@ packages:
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
 
+  magic-regexp@0.10.0:
+    resolution: {integrity: sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==}
+
   magic-string-ast@1.0.3:
     resolution: {integrity: sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==}
     engines: {node: '>=20.19.0'}
@@ -6803,6 +6915,15 @@ packages:
   oxc-minify@0.118.0:
     resolution: {integrity: sha512-Q7pxvY63QhzOVUrka5+cQ2JIe2hvWsX1F205L21q7kS3zvCkPZX3ts3rOoKBUtJFtNTggKBhVwPxal9i0QhOmg==}
     engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-parser@0.131.0:
+    resolution: {integrity: sha512-SJ3/7ZPbgie8dr5Z9BI/M51zZbpXba+hRSG0MDzVwMW5CRQg2fjYE0jHGlLX4eeiibGgC/mzoDFKSDHwVZEHRQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-walker@0.7.0:
+    resolution: {integrity: sha512-54B4KUhrzbzc4sKvKwVYm7E2PgeROpGba0/2nlNZMqfDyca+yOor5IMb4WLGBatGDT0nkzYdYuzylg7n3YfB7A==}
+    peerDependencies:
+      oxc-parser: '>=0.98.0'
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -8093,6 +8214,9 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  type-level-regexp@0.1.17:
+    resolution: {integrity: sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -8207,16 +8331,18 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unocss@66.5.10:
-    resolution: {integrity: sha512-h3OjHVKsYFiet7ZSgxD6+odC1bpx+N0JYP2bWy/vcqjrApaZmYg4CKmvxCFNxw1+qVoxyfhhjcVZHGUpf9jaKA==}
-    engines: {node: '>=14'}
+  unocss@66.7.2:
+    resolution: {integrity: sha512-yB0yOpJTtlyGH/HAe4QdnjgjSP6z9ItTdrObvagc8ZEwRY1D2GbfUABwDKyZzXs19gXebqThMG9f+W0hPhDIPA==}
     peerDependencies:
-      '@unocss/webpack': 66.5.10
-      vite: ^8.0.11
+      '@unocss/astro': 66.7.2
+      '@unocss/postcss': 66.7.2
+      '@unocss/webpack': 66.7.2
     peerDependenciesMeta:
-      '@unocss/webpack':
+      '@unocss/astro':
         optional: true
-      vite:
+      '@unocss/postcss':
+        optional: true
+      '@unocss/webpack':
         optional: true
 
   unpipe@1.0.0:
@@ -8244,9 +8370,9 @@ packages:
       '@nuxt/kit':
         optional: true
 
-  unplugin-vue-markdown@30.0.0:
-    resolution: {integrity: sha512-FVdKAb7jmZslfdkOCfm6jxHaUafltBpOXdoLvKY+0I0EeMmhxXTSzeDldwXFJeV0IH8LyIXIiU29E6gv02WJFQ==}
-    engines: {node: '>=20'}
+  unplugin-vue-markdown@32.0.0:
+    resolution: {integrity: sha512-K9uiYJF9kvngrN/NRx8fVPZFXiqJR7tbnXQV4mVFxjcsKhuiL6+vVQ5woam59RqeCDprecBmbg+cCGADz0somA==}
+    engines: {node: '>=22'}
     peerDependencies:
       vite: ^8.0.11
 
@@ -8492,9 +8618,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-
-  vue-flow-layout@0.2.0:
-    resolution: {integrity: sha512-zKgsWWkXq0xrus7H4Mc+uFs1ESrmdTXlO0YNbR6wMdPaFvosL3fMB8N7uTV308UhGy9UvTrGhIY7mVz9eN+L0Q==}
 
   vue-i18n@11.2.8:
     resolution: {integrity: sha512-vJ123v/PXCZntd6Qj5Jumy7UBmIuE92VrtdX+AXr+1WzdBHojiBxnAxdfctUFL+/JIN+VQH4BhsfTtiGsvVObg==}
@@ -8930,10 +9053,6 @@ snapshots:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
 
-  '@babel/parser@7.27.7':
-    dependencies:
-      '@babel/types': 7.29.0
-
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
@@ -8992,18 +9111,6 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
-
-  '@babel/traverse@7.27.7':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.0
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@5.5.0)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/traverse@7.29.0':
     dependencies:
@@ -9492,6 +9599,12 @@ snapshots:
       '@iconify/types': 2.0.0
       mlly: 1.8.2
 
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@internationalized/date@3.11.0':
     dependencies:
       '@swc/helpers': 0.5.18
@@ -9902,7 +10015,73 @@ snapshots:
   '@oxc-minify/binding-win32-x64-msvc@0.118.0':
     optional: true
 
+  '@oxc-parser/binding-android-arm-eabi@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.131.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.131.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.131.0':
+    optional: true
+
   '@oxc-project/types@0.128.0': {}
+
+  '@oxc-project/types@0.131.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -10833,150 +11012,134 @@ snapshots:
       unhead: 2.1.13
       vue: 3.5.22(typescript@5.9.3)
 
-  '@unocss/astro@66.5.10(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
-    dependencies:
-      '@unocss/core': 66.5.10
-      '@unocss/reset': 66.5.10
-      '@unocss/vite': 66.5.10(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
-    optionalDependencies:
-      vite: 8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
-
-  '@unocss/cli@66.5.10':
+  '@unocss/cli@66.7.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      '@unocss/config': 66.5.10
-      '@unocss/core': 66.5.10
-      '@unocss/preset-uno': 66.5.10
-      cac: 6.7.14
+      '@unocss/config': 66.7.2
+      '@unocss/core': 66.7.2
+      '@unocss/preset-wind3': 66.7.2
+      '@unocss/preset-wind4': 66.7.2
+      '@unocss/transformer-directives': 66.7.2
+      cac: 7.0.0
       chokidar: 5.0.0
       colorette: 2.0.20
       consola: 3.4.2
       magic-string: 0.30.21
       pathe: 2.0.3
-      perfect-debounce: 1.0.0
-      tinyglobby: 0.2.15
+      perfect-debounce: 2.1.0
+      tinyglobby: 0.2.16
       unplugin-utils: 0.3.1
 
-  '@unocss/config@66.5.10':
+  '@unocss/config@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
+      '@unocss/core': 66.7.2
+      colorette: 2.0.20
+      consola: 3.4.2
       unconfig: 7.5.0
 
-  '@unocss/core@66.5.10': {}
+  '@unocss/core@66.7.2': {}
 
-  '@unocss/extractor-arbitrary-variants@66.5.10':
+  '@unocss/extractor-arbitrary-variants@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
+      '@unocss/core': 66.7.2
 
-  '@unocss/inspector@66.5.10':
+  '@unocss/inspector@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
-      '@unocss/rule-utils': 66.5.10
+      '@unocss/core': 66.7.2
+      '@unocss/rule-utils': 66.7.2
       colorette: 2.0.20
       gzip-size: 6.0.0
       sirv: 3.0.2
-      vue-flow-layout: 0.2.0
 
-  '@unocss/postcss@66.5.10(postcss@8.5.14)':
+  '@unocss/preset-attributify@66.7.2':
     dependencies:
-      '@unocss/config': 66.5.10
-      '@unocss/core': 66.5.10
-      '@unocss/rule-utils': 66.5.10
-      css-tree: 3.2.1
-      postcss: 8.5.14
-      tinyglobby: 0.2.15
+      '@unocss/core': 66.7.2
 
-  '@unocss/preset-attributify@66.5.10':
+  '@unocss/preset-icons@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
-
-  '@unocss/preset-icons@66.5.10':
-    dependencies:
-      '@iconify/utils': 3.1.0
-      '@unocss/core': 66.5.10
+      '@iconify/utils': 3.1.3
+      '@unocss/core': 66.7.2
       ofetch: 1.5.1
 
-  '@unocss/preset-mini@66.5.10':
+  '@unocss/preset-mini@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
-      '@unocss/extractor-arbitrary-variants': 66.5.10
-      '@unocss/rule-utils': 66.5.10
+      '@unocss/core': 66.7.2
+      '@unocss/extractor-arbitrary-variants': 66.7.2
+      '@unocss/rule-utils': 66.7.2
 
-  '@unocss/preset-tagify@66.5.10':
+  '@unocss/preset-tagify@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
+      '@unocss/core': 66.7.2
 
-  '@unocss/preset-typography@66.5.10':
+  '@unocss/preset-typography@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
-      '@unocss/rule-utils': 66.5.10
+      '@unocss/core': 66.7.2
+      '@unocss/rule-utils': 66.7.2
 
-  '@unocss/preset-uno@66.5.10':
+  '@unocss/preset-uno@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
-      '@unocss/preset-wind3': 66.5.10
+      '@unocss/core': 66.7.2
+      '@unocss/preset-wind3': 66.7.2
 
-  '@unocss/preset-web-fonts@66.5.10':
+  '@unocss/preset-web-fonts@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
+      '@unocss/core': 66.7.2
       ofetch: 1.5.1
 
-  '@unocss/preset-wind3@66.5.10':
+  '@unocss/preset-wind3@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
-      '@unocss/preset-mini': 66.5.10
-      '@unocss/rule-utils': 66.5.10
+      '@unocss/core': 66.7.2
+      '@unocss/preset-mini': 66.7.2
+      '@unocss/rule-utils': 66.7.2
 
-  '@unocss/preset-wind4@66.5.10':
+  '@unocss/preset-wind4@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
-      '@unocss/extractor-arbitrary-variants': 66.5.10
-      '@unocss/rule-utils': 66.5.10
+      '@unocss/core': 66.7.2
+      '@unocss/extractor-arbitrary-variants': 66.7.2
+      '@unocss/rule-utils': 66.7.2
 
-  '@unocss/preset-wind@66.5.10':
+  '@unocss/preset-wind@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
-      '@unocss/preset-wind3': 66.5.10
+      '@unocss/core': 66.7.2
+      '@unocss/preset-wind3': 66.7.2
 
-  '@unocss/reset@66.5.10': {}
+  '@unocss/reset@66.7.2': {}
 
-  '@unocss/rule-utils@66.5.10':
+  '@unocss/rule-utils@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
+      '@unocss/core': 66.7.2
       magic-string: 0.30.21
 
-  '@unocss/transformer-attributify-jsx@66.5.10':
+  '@unocss/transformer-attributify-jsx@66.7.2':
     dependencies:
-      '@babel/parser': 7.27.7
-      '@babel/traverse': 7.27.7
-      '@unocss/core': 66.5.10
-    transitivePeerDependencies:
-      - supports-color
+      '@unocss/core': 66.7.2
+      oxc-parser: 0.131.0
+      oxc-walker: 0.7.0(oxc-parser@0.131.0)
 
-  '@unocss/transformer-compile-class@66.5.10':
+  '@unocss/transformer-compile-class@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
+      '@unocss/core': 66.7.2
 
-  '@unocss/transformer-directives@66.5.10':
+  '@unocss/transformer-directives@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
-      '@unocss/rule-utils': 66.5.10
+      '@unocss/core': 66.7.2
+      '@unocss/rule-utils': 66.7.2
       css-tree: 3.2.1
 
-  '@unocss/transformer-variant-group@66.5.10':
+  '@unocss/transformer-variant-group@66.7.2':
     dependencies:
-      '@unocss/core': 66.5.10
+      '@unocss/core': 66.7.2
 
-  '@unocss/vite@66.5.10(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@unocss/vite@66.7.2(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      '@unocss/config': 66.5.10
-      '@unocss/core': 66.5.10
-      '@unocss/inspector': 66.5.10
+      '@unocss/config': 66.7.2
+      '@unocss/core': 66.7.2
+      '@unocss/inspector': 66.7.2
       chokidar: 5.0.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       unplugin-utils: 0.3.1
       vite: 8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
 
@@ -13210,8 +13373,6 @@ snapshots:
       kind-of: 6.0.3
       which: 1.3.1
 
-  globals@11.12.0: {}
-
   globals@15.15.0: {}
 
   globals@17.5.0: {}
@@ -13929,6 +14090,16 @@ snapshots:
       yallist: 3.1.1
 
   lunr@2.3.9: {}
+
+  magic-regexp@0.10.0:
+    dependencies:
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      regexp-tree: 0.1.27
+      type-level-regexp: 0.1.17
+      ufo: 1.6.3
+      unplugin: 2.3.11
 
   magic-string-ast@1.0.3:
     dependencies:
@@ -14726,6 +14897,36 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
     optional: true
+
+  oxc-parser@0.131.0:
+    dependencies:
+      '@oxc-project/types': 0.131.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.131.0
+      '@oxc-parser/binding-android-arm64': 0.131.0
+      '@oxc-parser/binding-darwin-arm64': 0.131.0
+      '@oxc-parser/binding-darwin-x64': 0.131.0
+      '@oxc-parser/binding-freebsd-x64': 0.131.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.131.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.131.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.131.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.131.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.131.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.131.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.131.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.131.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.131.0
+      '@oxc-parser/binding-linux-x64-musl': 0.131.0
+      '@oxc-parser/binding-openharmony-arm64': 0.131.0
+      '@oxc-parser/binding-wasm32-wasi': 0.131.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.131.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.131.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.131.0
+
+  oxc-walker@0.7.0(oxc-parser@0.131.0):
+    dependencies:
+      magic-regexp: 0.10.0
+      oxc-parser: 0.131.0
 
   p-limit@2.3.0:
     dependencies:
@@ -16123,6 +16324,8 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  type-level-regexp@0.1.17: {}
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -16288,32 +16491,27 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unocss@66.5.10(postcss@8.5.14)(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)):
+  unocss@66.7.2(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
-      '@unocss/astro': 66.5.10(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
-      '@unocss/cli': 66.5.10
-      '@unocss/core': 66.5.10
-      '@unocss/postcss': 66.5.10(postcss@8.5.14)
-      '@unocss/preset-attributify': 66.5.10
-      '@unocss/preset-icons': 66.5.10
-      '@unocss/preset-mini': 66.5.10
-      '@unocss/preset-tagify': 66.5.10
-      '@unocss/preset-typography': 66.5.10
-      '@unocss/preset-uno': 66.5.10
-      '@unocss/preset-web-fonts': 66.5.10
-      '@unocss/preset-wind': 66.5.10
-      '@unocss/preset-wind3': 66.5.10
-      '@unocss/preset-wind4': 66.5.10
-      '@unocss/transformer-attributify-jsx': 66.5.10
-      '@unocss/transformer-compile-class': 66.5.10
-      '@unocss/transformer-directives': 66.5.10
-      '@unocss/transformer-variant-group': 66.5.10
-      '@unocss/vite': 66.5.10(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
-    optionalDependencies:
-      vite: 8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
+      '@unocss/cli': 66.7.2
+      '@unocss/core': 66.7.2
+      '@unocss/preset-attributify': 66.7.2
+      '@unocss/preset-icons': 66.7.2
+      '@unocss/preset-mini': 66.7.2
+      '@unocss/preset-tagify': 66.7.2
+      '@unocss/preset-typography': 66.7.2
+      '@unocss/preset-uno': 66.7.2
+      '@unocss/preset-web-fonts': 66.7.2
+      '@unocss/preset-wind': 66.7.2
+      '@unocss/preset-wind3': 66.7.2
+      '@unocss/preset-wind4': 66.7.2
+      '@unocss/transformer-attributify-jsx': 66.7.2
+      '@unocss/transformer-compile-class': 66.7.2
+      '@unocss/transformer-directives': 66.7.2
+      '@unocss/transformer-variant-group': 66.7.2
+      '@unocss/vite': 66.7.2(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
     transitivePeerDependencies:
-      - postcss
-      - supports-color
+      - vite
 
   unpipe@1.0.0: {}
 
@@ -16351,13 +16549,13 @@ snapshots:
       - rollup
       - supports-color
 
-  unplugin-vue-markdown@30.0.0(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)):
+  unplugin-vue-markdown@32.0.0(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       '@mdit-vue/plugin-component': 3.0.2
       '@mdit-vue/plugin-frontmatter': 3.0.2
       '@mdit-vue/types': 3.0.2
       markdown-exit: 1.0.0-beta.9
-      unplugin: 2.3.11
+      unplugin: 3.0.0
       unplugin-utils: 0.3.1
       vite: 8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
 
@@ -16687,8 +16885,6 @@ snapshots:
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
-
-  vue-flow-layout@0.2.0: {}
 
   vue-i18n@11.2.8(vue@3.5.22(typescript@5.9.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -844,9 +844,15 @@ importers:
       '@unocss/reset':
         specifier: 'catalog:'
         version: 66.7.2
+      '@vitejs/plugin-vue':
+        specifier: 'catalog:'
+        version: 6.0.6(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.22(typescript@5.9.3))
       gray-matter:
         specifier: 'catalog:'
         version: 4.0.3
+      pinia:
+        specifier: 'catalog:'
+        version: 3.0.4(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))
       reka-ui:
         specifier: catalog:frontend
         version: 2.9.7(vue@3.5.22(typescript@5.9.3))
@@ -859,12 +865,27 @@ importers:
       unbuild:
         specifier: catalog:build
         version: 3.6.1(sass@1.99.0)(typescript@5.9.3)(vue-tsc@2.2.0(typescript@5.9.3))(vue@3.5.22(typescript@5.9.3))
+      unocss:
+        specifier: 'catalog:'
+        version: 66.7.2(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))
+      unplugin-vue-components:
+        specifier: 'catalog:'
+        version: 28.0.0(@babel/parser@7.29.0)(@nuxt/kit@3.21.0(magicast@0.5.2))(rollup@4.57.1)(vue@3.5.22(typescript@5.9.3))
       vite:
         specifier: ^8.0.11
         version: 8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
+      vite-plugin-vue-devtools:
+        specifier: 'catalog:'
+        version: 8.1.1(@nuxt/kit@3.21.0(magicast@0.5.2))(vite@8.0.11(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4))(vue@3.5.22(typescript@5.9.3))
+      vue:
+        specifier: 3.5.22
+        version: 3.5.22(typescript@5.9.3)
       vue-i18n:
         specifier: catalog:build
         version: 11.4.2(vue@3.5.22(typescript@5.9.3))
+      vue-router:
+        specifier: 'catalog:'
+        version: 5.0.6(@vue/compiler-sfc@3.5.27)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3)))(vue@3.5.22(typescript@5.9.3))
 
   packages/valaxy:
     dependencies:
@@ -11307,7 +11328,7 @@ snapshots:
       '@vue/shared': 3.5.22
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.9
+      postcss: 8.5.14
       source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.27':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ packages:
 overrides:
   '@types/markdown-it': ^14.1.2
   # Force all packages to use the same UnoCSS version to avoid type conflicts
-  unocss: 66.5.10
+  unocss: 66.7.2
   vue: catalog:frontend
 
 catalog:
@@ -66,6 +66,8 @@ catalog:
   '@types/splitpanes': ^2.2.6
   '@types/wicg-file-system-access': ^2023.10.7
   '@types/yargs': ^17.0.35
+  # Kept in lockstep with the pinned `unocss` (devtools client imports @unocss/reset/tailwind.css)
+  '@unocss/reset': 66.7.2
   '@vitejs/plugin-vue': ^6.0.6
   '@vue/devtools-api': 7.7.2
   '@vueuse/core': ^14.3.0
@@ -156,9 +158,10 @@ catalog:
   typedoc: ^0.28.19
   typedoc-plugin-markdown: ^4.11.0
   typedoc-vitepress-theme: ^1.1.2
-  unocss: 66.5.10
+  unocss: 66.7.2
+  # Pinned to 28.0.0: 28.1.0+ breaks component override order (clientRoot/themeRoot), see #505
   unplugin-vue-components: 28.0.0
-  unplugin-vue-markdown: ^30.0.0
+  unplugin-vue-markdown: ^32.0.0
   valaxy-addon-artalk: ^0.1.3
   valaxy-addon-git-log: ^0.5.0
   vanilla-lazyload: ^19.1.3


### PR DESCRIPTION
## Summary

Fixes the unmet peer dependency warnings reported under Vite 8 (#709) by bumping the offending plugins to versions that declare Vite 8 support.

`pnpm i` warned that two catalog plugins did not declare Vite 8 in their peer ranges:

- `unocss` / `@unocss/vite` `66.5.10` → vite peer capped at `^7.0.0-0`
- `unplugin-vue-markdown` `^30.0.0` → vite peer capped at `^7.0.0`

> Note: silencing these via `peerDependencyRules` would only fix the **monorepo's** install — it wouldn't help end users (like the reporter), since those rules don't ship in the published package. The published catalog versions had to be bumped.

## Changes (commit 1 — deps)

- **`unocss` `66.5.10` → `66.7.2`** (catalog **and** `overrides`; `@unocss/vite@66.7.2` peer is `^5 || ^6 || ^7 || ^8`).
- **`unplugin-vue-markdown` `^30.0.0` → `^32.0.0`** (the only release that declares the Vite 8 peer; includes `^8.0.0-0`).
- **`engines.node` `^18 || >=20` → `>=22.12.0`** across root / `valaxy` / `create-valaxy`, plus docs (getting-started EN/ZH, deploy Dockerfile → `node:22-alpine`) and `CLAUDE.md`. See below.
- **Declare `@unocss/reset`** explicitly in `@valaxyjs/devtools` (catalog + devDependencies) — its client entry imports `@unocss/reset/tailwind.css`, which previously resolved only via a hoisted transitive of `unocss@66.5.10`; `66.7.2` no longer pulls it in, which broke `vite build src/client` on a fresh install.
- Documented the `unplugin-vue-components@28.0.0` pin (#505) with a comment.

## ⚠️ BREAKING CHANGE — minimum Node is now `>=22.12.0`

`unplugin-vue-markdown@32` — the only version that declares Vite 8 peer support — requires Node `>=22`, and Vite 8 itself requires `^20.19 || >=22.12`. The intersection is **`>=22.12.0`**, so Node 18/20 are dropped in v1.0. CI already runs `lts/*` (Node 22+). (Per maintainer decision over keeping markdown on v30 with a residual warning.)

### #505 safety

`unplugin-vue-markdown` (v30 and v32) has **no dependency on `unplugin-vue-components`** — it still resolves to exactly `28.0.0` with markdown@32 installed. So this bump is unrelated to the #505 override-order bug, which remains fixed by the separate `unplugin-vue-components@28.0.0` pin.

The `vite-ssg` / `beasties` warning from the original report no longer applies — the legacy `vite-ssg` engine was removed in v1.0 (#706).

## Test hardening (commit 2 — `test(e2e)`)

The PR's first CI run surfaced a flaky Playwright failure: `e2e/docs/search.spec.ts` gated `page.goto` on `waitUntil: 'networkidle'`, which never settles against the Vite dev server (HMR, UnoCSS dev updates, the git-log addon's GitHub API calls, async DocSearch chunks keep the network busy) → navigation timed out under CI load.

- Switched to `waitUntil: 'domcontentloaded'` + the existing `waitForHydration` helper (waits for Vue's `data-v-app` — a deterministic "app is interactive" signal that doesn't depend on the network going quiet), and expanded the helper docs.
- `e2e/theme-yun/index.spec.ts` **intentionally keeps `networkidle`**: its mount on the served demo build is network-gated (external analytics/resources never resolve in the sandbox), so `data-v-app` is not a reliable signal there and `networkidle` is the appropriate wait. Verified that the alternatives break that test.

## Verification

- `pnpm i` — no `vite` / `unocss` / `unplugin-vue-markdown` peer warnings
- `pnpm run build` ✅ (incl. devtools `build:client`) · `docs:build` ✅ · `build:demo` ✅
- `pnpm typecheck` ✅ · `pnpm test` 295/295 ✅ · `pnpm lint` ✅
- Playwright E2E ✅ (docs search hardened; ran the changed spec repeatedly with no flakes)
- All 14 CI checks green.

Closes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)