### PR TITLE
fix(theme-yun): render YunAdBoard placeholder as a comment node to fix SSR hydration (#711)

### DIFF
--- a/packages/valaxy-theme-yun/components/YunAdBoard.vue
+++ b/packages/valaxy-theme-yun/components/YunAdBoard.vue
@@ -1,4 +1,9 @@
 <template>
-  <!-- eslint-disable-next-line vue/no-lone-template empty -->
-  <template />
+  <!--
+    Empty placeholder, meant to be overridden by the user (see demo/yun/components/YunAdBoard.vue).
+    `v-if="false"` renders a comment node instead of a real element: this avoids the SSR hydration
+    crash a raw `<template>` causes (#711), while still adding no gap to the parent flex layout,
+    which an empty `<div>` would (ab57216f).
+  -->
+  <template v-if="false" />
 </template>

--- a/test/client/yun-adboard.test.ts
+++ b/test/client/yun-adboard.test.ts
@@ -3,11 +3,11 @@ import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it, vi } from 'vitest'
+// Namespace imports: the whole `vue` / `vue/server-renderer` modules are handed to
+// the compiled render functions (see `compileSfc`), so we call members off them too.
 import * as Vue from 'vue'
-import { createSSRApp } from 'vue'
 import { compileTemplate, parse } from 'vue/compiler-sfc'
 import * as serverRenderer from 'vue/server-renderer'
-import { renderToString } from 'vue/server-renderer'
 
 const componentPath = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -37,7 +37,7 @@ function compileSfc(source: string) {
 describe('valaxy-theme-yun YunAdBoard (#711)', () => {
   it('renders an empty placeholder without a raw <template> element', async () => {
     const component = compileSfc(readFileSync(componentPath, 'utf-8'))
-    const html = await renderToString(createSSRApp(component))
+    const html = await serverRenderer.renderToString(Vue.createSSRApp(component))
 
     // A serialized `<template>` element in the SSR output is exactly what breaks
     // hydration (`Failed to execute 'replaceChild' on 'Node'`) in #711.
@@ -48,7 +48,7 @@ describe('valaxy-theme-yun YunAdBoard (#711)', () => {
 
   it('hydrates the SSR output without a mismatch', async () => {
     const component = compileSfc(readFileSync(componentPath, 'utf-8'))
-    const html = await renderToString(createSSRApp(component))
+    const html = await serverRenderer.renderToString(Vue.createSSRApp(component))
 
     const container = document.createElement('div')
     container.innerHTML = html
@@ -60,7 +60,7 @@ describe('valaxy-theme-yun YunAdBoard (#711)', () => {
     // `finally` guarantees the console spies are restored even when an assertion
     // throws (e.g. on a regression), so the mocks never leak into later tests.
     try {
-      expect(() => createSSRApp(component).mount(container)).not.toThrow()
+      expect(() => Vue.createSSRApp(component).mount(container)).not.toThrow()
       expect(logs.filter(log => log.includes('Hydration'))).toEqual([])
     }
     finally {
@@ -72,7 +72,7 @@ describe('valaxy-theme-yun YunAdBoard (#711)', () => {
   it('regression guard: a raw <template /> placeholder serializes as a <template> element', async () => {
     // Documents the broken form replaced in #711 — keep YunAdBoard from regressing to it.
     const broken = compileSfc('<template>\n  <template />\n</template>')
-    const html = await renderToString(createSSRApp(broken))
+    const html = await serverRenderer.renderToString(Vue.createSSRApp(broken))
     expect(html).toContain('<template>')
   })
 })

--- a/test/client/yun-adboard.test.ts
+++ b/test/client/yun-adboard.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it, vi } from 'vitest'
+import * as Vue from 'vue'
+import { createSSRApp } from 'vue'
+import { compileTemplate, parse } from 'vue/compiler-sfc'
+import * as serverRenderer from 'vue/server-renderer'
+import { renderToString } from 'vue/server-renderer'
+
+const componentPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../packages/valaxy-theme-yun/components/YunAdBoard.vue',
+)
+
+/**
+ * Compile an SFC `<template>` source into a render / ssrRender pair without
+ * needing the Vue Vite plugin, so we can assert on the real component output.
+ */
+function compileSfc(source: string) {
+  const { descriptor } = parse(source, { filename: 'YunAdBoard.vue' })
+  const template = descriptor.template?.content ?? ''
+  const shared = { filename: 'YunAdBoard.vue', id: 'data-v-test', compilerOptions: { mode: 'function' as const, comments: false } }
+
+  // eslint-disable-next-line no-new-func
+  const render = new Function('Vue', compileTemplate({ ...shared, source: template, ssr: false }).code)(Vue)
+  // eslint-disable-next-line no-new-func
+  const ssrRender = new Function('Vue', 'require', compileTemplate({ ...shared, source: template, ssr: true }).code)(
+    Vue,
+    (id: string) => (id === 'vue/server-renderer' ? serverRenderer : Vue),
+  )
+
+  return { render, ssrRender }
+}
+
+describe('valaxy-theme-yun YunAdBoard (#711)', () => {
+  it('renders an empty placeholder without a raw <template> element', async () => {
+    const component = compileSfc(readFileSync(componentPath, 'utf-8'))
+    const html = await renderToString(createSSRApp(component))
+
+    // A serialized `<template>` element in the SSR output is exactly what breaks
+    // hydration (`Failed to execute 'replaceChild' on 'Node'`) in #711.
+    expect(html).not.toContain('<template')
+    // The default ad board is an overridable placeholder: it renders nothing visible.
+    expect(html.replace(/<!--[\s\S]*?-->/g, '').trim()).toBe('')
+  })
+
+  it('hydrates the SSR output without a mismatch', async () => {
+    const component = compileSfc(readFileSync(componentPath, 'utf-8'))
+    const html = await renderToString(createSSRApp(component))
+
+    const container = document.createElement('div')
+    container.innerHTML = html
+
+    const logs: string[] = []
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => logs.push(args.join(' ')))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation((...args) => logs.push(args.join(' ')))
+
+    expect(() => createSSRApp(component).mount(container)).not.toThrow()
+
+    errorSpy.mockRestore()
+    warnSpy.mockRestore()
+    expect(logs.filter(log => log.includes('Hydration'))).toEqual([])
+  })
+
+  it('regression guard: a raw <template /> placeholder serializes as a <template> element', async () => {
+    // Documents the broken form replaced in #711 — keep YunAdBoard from regressing to it.
+    const broken = compileSfc('<template>\n  <template />\n</template>')
+    const html = await renderToString(createSSRApp(broken))
+    expect(html).toContain('<template>')
+  })
+})

--- a/test/client/yun-adboard.test.ts
+++ b/test/client/yun-adboard.test.ts
@@ -57,11 +57,16 @@ describe('valaxy-theme-yun YunAdBoard (#711)', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => logs.push(args.join(' ')))
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation((...args) => logs.push(args.join(' ')))
 
-    expect(() => createSSRApp(component).mount(container)).not.toThrow()
-
-    errorSpy.mockRestore()
-    warnSpy.mockRestore()
-    expect(logs.filter(log => log.includes('Hydration'))).toEqual([])
+    // `finally` guarantees the console spies are restored even when an assertion
+    // throws (e.g. on a regression), so the mocks never leak into later tests.
+    try {
+      expect(() => createSSRApp(component).mount(container)).not.toThrow()
+      expect(logs.filter(log => log.includes('Hydration'))).toEqual([])
+    }
+    finally {
+      errorSpy.mockRestore()
+      warnSpy.mockRestore()
+    }
   })
 
   it('regression guard: a raw <template /> placeholder serializes as a <template> element', async () => {


### PR DESCRIPTION
## Summary

Fixes #711 — opening a post page directly throws `TypeError: Failed to execute 'replaceChild' on 'Node': parameter 1 is not of type 'Node'` on any page that renders `YunLayoutLeft`.

## Root cause

`YunAdBoard.vue` is an empty, user-overridable placeholder. It rendered a bare `<template />`, which Vue's SSR compiler serializes as a real `<template></template>` **element**:

```js
// ssrRender (raw `<template />`)
_push(`<template></template>`)
```

On the client the component resolves to nothing, so during hydration Vue tries to replace that SSR `<template>` DOM node with `null` → `replaceChild` throws.

## Fix

Render the placeholder with `<template v-if="false" />` so it emits a **comment node** consistently in both SSR and on the client:

```js
// ssrRender → `<!---->`     // client render → createCommentVNode("v-if", true)
```

SSR and client now agree, so hydration matches.

### Why not `<div />` (the fix suggested in the issue)?

A comment node is **not a flex item**, so it adds no gap to the parent `.yun-layout-left` (`flex` + `gap-4`) layout. An empty `<div>` *is* a flex item and would reintroduce the exact spacing bug that commit `ab57216f` ("empty template for YunAdBoard parent gap size") originally fixed by switching `<div />` → `<template />`. `<template v-if="false" />` satisfies both constraints: no hydration crash **and** no gap.

## Test

Adds `test/client/yun-adboard.test.ts`, which compiles the **real** `YunAdBoard.vue`, and asserts:

1. its SSR output contains no raw `<template>` element;
2. it renders nothing visible (comment-only);
3. it hydrates in jsdom with no mismatch.

A control case confirms the old `<template />` form serializes back to a `<template>` element (the regression guard). Reverting the component to the broken form makes the suite fail — test 2 reproduces the original `TypeError` exactly.

## Verification

- `pnpm run build` ✅
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (the 2 failing `test/build/*` cases require a prior `pnpm demo:build` and are unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)