### PR TITLE
feat(theme-yun): polish friend link cards

### DIFF
--- a/packages/valaxy-theme-yun/components/YunLinkItem.vue
+++ b/packages/valaxy-theme-yun/components/YunLinkItem.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import type { LinkType } from '../types'
-import { yunSpringVariants } from '../composables/animation'
 import { onImgError } from '../utils'
 
 const props = defineProps<{
-  i: number
   errorImg?: string
   link: LinkType
 }>()
@@ -13,34 +11,38 @@ function onError(e: Event) {
   onImgError(e, props.errorImg)
 }
 
-const motionVariants = yunSpringVariants({ i: props.i })
+function getLinkLabel(link: LinkType) {
+  return [link.name, link.blog, link.desc].filter(Boolean).join(' · ')
+}
 </script>
 
 <template>
   <li
-    v-motion="motionVariants"
-    class="yun-link-item inline-flex"
+    class="yun-link-item"
     :style="{
       '--primary-color': link.color,
     }"
   >
     <a
-      class="yun-link-url" p="x-4 y-2"
+      class="yun-link-url"
       :href="link.url" :title="link.name"
-      alt="portrait" rel="friend" target="_blank"
+      :aria-label="getLinkLabel(link)"
+      rel="friend noopener noreferrer" target="_blank"
     >
       <div class="yun-link-left">
-        <div class="yun-link-avatar size-16 overflow-hidden flex-center">
+        <div class="yun-link-avatar">
           <img
-            class="size-full object-center object-cover m-0! max-w-unset!"
+            class="yun-link-avatar-img"
+            alt=""
+            decoding="async"
             loading="lazy"
-            :src="link.avatar" :alt="link.name"
+            :src="link.avatar"
             @error="onError"
           >
         </div>
       </div>
-      <div class="yun-link-info" m="l-2">
-        <div class="yun-link-blog" font="serif black">{{ link.blog }}</div>
+      <div class="yun-link-info">
+        <div class="yun-link-blog">{{ link.blog }}</div>
         <div class="yun-link-desc">{{ link.desc }}</div>
       </div>
     </a>

--- a/packages/valaxy-theme-yun/components/YunLinks.vue
+++ b/packages/valaxy-theme-yun/components/YunLinks.vue
@@ -35,19 +35,19 @@ const isUrlSource = computed(() => typeof props.links === 'string')
       hydration mismatch (SSG renders empty list, client fills it).
     -->
     <ClientOnly v-if="isUrlSource">
-      <ul class="yun-link-items" flex="center wrap">
+      <ul class="yun-link-items">
         <YunLinkItem
-          v-for="link, i in data"
+          v-for="link in data"
           :key="link.url"
-          :i="i" :link="link" :error-img="errorImg"
+          :link="link" :error-img="errorImg"
         />
       </ul>
     </ClientOnly>
-    <ul v-else class="yun-link-items" flex="center wrap">
+    <ul v-else class="yun-link-items">
       <YunLinkItem
-        v-for="link, i in data"
+        v-for="link in data"
         :key="link.url"
-        :i="i" :link="link" :error-img="errorImg"
+        :link="link" :error-img="errorImg"
       />
     </ul>
   </div>
@@ -56,59 +56,172 @@ const isUrlSource = computed(() => typeof props.links === 'string')
 <style lang="scss">
 .yun-links {
   .yun-link-items {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+    gap: 1rem;
+    margin: 1.5rem 0;
     padding-left: 0;
+    list-style: none;
+  }
+
+  .yun-link-item {
+    display: flex;
+    min-width: 0;
   }
 
   .yun-link-url {
-    --smc-link-color: var(--primary-color);
+    --yun-link-accent: var(--primary-color, var(--va-c-primary));
 
-    display: inline-flex;
-    text-align: center;
-    justify-self: center;
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.875rem;
+    box-sizing: border-box;
+    width: 100%;
+    min-width: 0;
+    min-height: 5.5rem;
+    padding: 0.875rem 1rem;
+    overflow: hidden;
+    color: var(--va-c-text);
+    text-align: left;
     line-height: 1.5;
-    margin: 0.5rem;
-    transition: var(--va-transition-duration-fast);
-    color: var(--primary-color, black);
-    border: 1px solid var(--primary-color, gray);
+    background-color: var(--va-c-bg-light);
+    border: 1px solid var(--va-c-border);
+    border-radius: 0.75rem;
+    box-shadow: inset 3px 0 0 var(--yun-link-accent);
+    isolation: isolate;
+    transition:
+      transform var(--va-transition-duration-fast) ease,
+      border-color var(--va-transition-duration-fast) ease,
+      background-color var(--va-transition-duration-fast) ease,
+      box-shadow var(--va-transition-duration-fast) ease;
+
+    &::before {
+      position: absolute;
+      z-index: 0;
+      inset: 0;
+      pointer-events: none;
+      background:
+        radial-gradient(
+          circle at 3.25rem 50%,
+          color-mix(in srgb, var(--yun-link-accent) 18%, transparent) 0,
+          color-mix(in srgb, var(--yun-link-accent) 7%, transparent) 42%,
+          transparent 74%
+        );
+      content: '';
+      opacity: 0;
+      transition: opacity var(--va-transition-duration-fast) ease;
+    }
 
     &:hover {
-      color: white;
-      background-color: var(--primary-color, gray);
-      box-shadow: 0 2px 20px var(--primary-color, gray);
+      color: var(--va-c-text);
+      background-color: var(--va-c-bg-soft);
+      box-shadow:
+        inset 3px 0 0 var(--yun-link-accent),
+        0 10px 28px rgb(0 0 0 / 0.1);
+      transform: translateY(-2px);
+    }
+
+    &:hover::before,
+    &:focus-visible::before {
+      opacity: 1;
+    }
+
+    &:hover:not(:focus-visible) {
+      border-color: var(--yun-link-accent);
+    }
+
+    &:focus-visible {
+      color: var(--va-c-text);
+      border-color: var(--va-c-border);
+      outline: 2px solid var(--va-c-primary);
+      outline-offset: 2px;
+    }
+
+    &:active {
+      transform: scale(0.985);
     }
 
     .yun-link {
       &-left {
+        position: relative;
+        z-index: 1;
+        flex: 0 0 auto;
         line-height: 0;
       }
 
       &-avatar {
-        margin: 0;
-        display: inline-flex;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 3.5rem;
+        height: 3.5rem;
+        overflow: hidden;
         border-radius: 50%;
         background-color: #fff;
-        border: 1px solid var(--primary-color, gray);
-        transition: var(--va-transition-duration-moderate);
+        border: 2px solid var(--yun-link-accent);
+        transition: transform var(--va-transition-duration-fast) ease;
+      }
 
-        &:hover {
-          box-shadow: 0 0 20px rgb(0 0 0 / 0.1);
-        }
+      &-avatar-img {
+        width: 100%;
+        height: 100%;
+        margin: 0 !important;
+        object-fit: cover;
+        object-position: center;
+      }
+
+      &-blog {
+        overflow: hidden;
+        color: var(--va-c-text);
+        font-family: var(--va-font-serif);
+        font-size: 1rem;
+        font-weight: 700;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
 
       &-desc {
-        font-size: 0.8rem;
-        width: 10rem;
-        white-space: nowrap;
-        text-overflow: ellipsis;
+        display: -webkit-box;
         overflow: hidden;
+        color: var(--va-c-text-light);
+        font-size: 0.875rem;
+        line-height: 1.4;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
       }
+    }
+
+    &:hover .yun-link-avatar {
+      transform: scale(1.04);
     }
   }
 
   .yun-link-info {
-    display: inline-flex;
+    position: relative;
+    z-index: 1;
+    display: flex;
     flex-direction: column;
     justify-content: center;
+    gap: 0.125rem;
+    min-width: 0;
+    flex: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .yun-links {
+    .yun-link-url,
+    .yun-link-avatar,
+    .yun-link-url::before {
+      transition-duration: 0.01ms;
+    }
+
+    .yun-link-url:hover,
+    .yun-link-url:active,
+    .yun-link-url:hover .yun-link-avatar {
+      transform: none;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Summary

- redesign Yun theme friend links as a responsive, content-first card grid
- improve link semantics, keyboard focus, image loading, and long-text handling
- add a CSS-only accent glow with accessible hover, active, and reduced-motion states

## Why

The previous cards used the friend color as the full hover surface and staggered spring motion across the list. On larger friend lists this reduced readability, delayed content presentation, and made focus and hover states harder to distinguish.

## Impact

Friend links now preserve semantic theme colors while using each friend color as a restrained accent. Cards are easier to scan in light and dark modes, remain usable on narrow screens, and do not add pointer listeners or runtime animation dependencies.

## Validation

- `pnpm exec stylelint packages/valaxy-theme-yun/components/YunLinks.vue`
- `pnpm exec eslint packages/valaxy-theme-yun/components/YunLinks.vue packages/valaxy-theme-yun/components/YunLinkItem.vue`
- `pnpm demo:build`
- `git diff --check`
- browser-verified default, hover, keyboard focus, and dark-mode states