### PR TITLE
release: v1.0.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@valaxyjs/monorepo",
   "type": "module",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "private": true,
   "packageManager": "pnpm@10.34.4",
   "description": "📄 Vite & Vue powered static blog generator.",

--- a/packages/@valaxyjs/utils/package.json
+++ b/packages/@valaxyjs/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@valaxyjs/utils",
   "type": "module",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A utility library for Valaxy",
   "author": {
     "name": "Valaxy",

--- a/packages/create-valaxy/package.json
+++ b/packages/create-valaxy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-valaxy",
   "type": "module",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Create Starter Template for Valaxy",
   "author": {
     "email": "me@yunyoujun.cn",

--- a/packages/create-valaxy/template-blog/package.json
+++ b/packages/create-valaxy/template-blog/package.json
@@ -12,8 +12,8 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "valaxy": "1.0.0-beta.1",
-    "valaxy-theme-yun": "1.0.0-beta.1"
+    "valaxy": "1.0.0-beta.2",
+    "valaxy-theme-yun": "1.0.0-beta.2"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@valaxyjs/devtools",
   "type": "module",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "DevTools for Valaxy",
   "license": "MIT",
   "repository": {

--- a/packages/valaxy-theme-press/package.json
+++ b/packages/valaxy-theme-press/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valaxy-theme-press",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Docs (VitePress-like) theme for Valaxy",
   "author": {
     "email": "me@yunyoujun.cn",

--- a/packages/valaxy-theme-yun/package.json
+++ b/packages/valaxy-theme-yun/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valaxy-theme-yun",
   "type": "module",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Default theme (Yun) for Valaxy — a Vite & Vue powered static blog generator",
   "author": {
     "email": "me@yunyoujun.cn",

--- a/packages/valaxy/package.json
+++ b/packages/valaxy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valaxy",
   "type": "module",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "📄 Vite & Vue powered static blog generator.",
   "author": {
     "email": "me@yunyoujun.cn",


### PR DESCRIPTION
## Summary

- bump the Valaxy release packages from `1.0.0-beta.1` to `1.0.0-beta.2`
- update the starter blog template to install `valaxy` and `valaxy-theme-yun` `1.0.0-beta.2`

## Why

This prepares the next prerelease after `v1.0.0-beta.1`, including the route-meta reset fix and the Yun friend-link card redesign merged in #715.

## Impact

Merging this PR updates package metadata only. It does not create a git tag or publish packages. After merge, pushing tag `v1.0.0-beta.2` will trigger the Release workflow, publish prerelease packages under the npm `next` dist-tag, and generate the GitHub release changelog.

## Validation

- `pnpm run build:all`
- `git diff --check`
- parsed all changed package manifests as JSON
