### PR TITLE
fix(addon-waline): add missing '.' export to package.json

### DIFF
--- a/packages/valaxy-addon-waline/package.json
+++ b/packages/valaxy-addon-waline/package.json
@@ -11,7 +11,8 @@
     "waline"
   ],
   "exports": {
-    "./*": "./*"
+    "./*": "./*",
+    ".": "./index.ts"
   },
   "main": "index.ts",
   "types": "index.d.ts",

--- a/packages/valaxy-addon-waline/package.json
+++ b/packages/valaxy-addon-waline/package.json
@@ -11,8 +11,11 @@
     "waline"
   ],
   "exports": {
-    "./*": "./*",
-    ".": "./index.ts"
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.ts"
+    },
+    "./*": "./*"
   },
   "main": "index.ts",
   "types": "index.d.ts",


### PR DESCRIPTION
### Description

The "exports" field in package.json only covers subpaths via "./*", but lacks the "." root entry. This causes projects using `moduleResolution: "bundler"` to fail with "Cannot find module 'valaxy-addon-waline'" when importing from the package root.

### Solve

Add missing '.' entry to export filed.

(or just delete the `exports` item entirely because this item doesn't exist in the other official addons, but adding `"."` keeps the existing subpath exports intact.)