### PR TITLE
feat(addons): add valaxy-addon-giscus to addon gallery

### DIFF
--- a/docs/data/addons.ts
+++ b/docs/data/addons.ts
@@ -226,6 +226,18 @@ export const addons = [
     },
     tags: ['food', 'map'],
   },
+  {
+    name: 'valaxy-addon-giscus',
+    author: 'CNskarin',
+    icon: 'i-ri-chat-3-line',
+    repo: 'https://github.com/CNskarin/valaxy-addon-giscus',
+    kind: 'community',
+    description: {
+      'en': 'Giscus comment system for Valaxy, powered by GitHub Discussions.',
+      'zh-CN': '为 Valaxy 集成 Giscus 评论系统（GitHub Discussions 驱动）。',
+    },
+    tags: ['comment', 'giscus'],
+  },
 ] satisfies readonly ValaxyAddon[]
 
 export const officialAddons = addons.filter(addon => addon.kind === 'official')


### PR DESCRIPTION
## Description

Add [valaxy-addon-giscus](https://github.com/CNskarin/valaxy-addon-giscus) to the community addon gallery.

A Giscus comment system addon for Valaxy — comments powered by GitHub Discussions. No backend needed, zero cost.

### Features

- Giscus (GitHub Discussions) comments for Valaxy sites
- Auto light/dark theme switching following the site's color mode
- Zero-config integration with the default yun theme (overrides `YunComment`)
- Full options support: mapping, lang, theme, input position, loading, etc.
- MIT licensed

### Usage

```ts
import { addonGiscus } from 'valaxy-addon-giscus'

export default defineValaxyConfig({
  siteConfig: { comment: { enable: true } },
  addons: [addonGiscus({
    repo: 'OWNER/REPO',
    repoId: 'R_kgDO...',
    category: 'General',
    categoryId: 'DIC_...',
  })],
})
```

Install: `pnpm add valaxy-addon-giscus`

This adds a single entry to the gallery data file, following the existing community addon format.