### PR TITLE
feat(addon-moments): add moments like function

### DIFF
--- a/demo/yun/edge-functions/README.md
+++ b/demo/yun/edge-functions/README.md
@@ -1,0 +1,27 @@
+# Moments like on EdgeOne
+
+The moments page talks only to the HTTP endpoint configured in
+`pages/moments/index.md`. Storage is a deployment concern and is not exposed to
+the browser.
+
+For EdgeOne Makers:
+
+1. Create or choose a KV namespace.
+2. Bind that namespace to the deployed project with the variable name
+   `moments_like`.
+3. Make sure this `edge-functions` directory is under the project's configured
+   root directory.
+4. Deploy the project. The file at `api/moments-like.js` becomes
+   `/api/moments-like`.
+
+The namespace can have any name and does not need pre-created moment records.
+The function hashes each moment route path to a KV-compatible SHA-256 key and
+creates the record on the first like.
+
+EdgeOne KV does not expose an atomic increment/decrement operation. Concurrent
+updates may overwrite each other, so this example is an eventually consistent
+lightweight counter rather than a transactionally exact counter.
+
+Other hosting providers can implement the same endpoint contract with their own
+serverless function and storage. Sites without a server-side storage option
+should leave `moments.likes.enabled` disabled.

--- a/demo/yun/edge-functions/api/moments-like.js
+++ b/demo/yun/edge-functions/api/moments-like.js
@@ -1,0 +1,86 @@
+/* global moments_like */
+
+const JSON_HEADERS = {
+  'Cache-Control': 'no-store',
+  'Content-Type': 'application/json; charset=utf-8',
+}
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: JSON_HEADERS,
+  })
+}
+
+function isMomentPath(value) {
+  if (typeof value !== 'string' || value.length <= '/moments/'.length || value.length > 512 || !value.startsWith('/moments/'))
+    return false
+  if ([',', '?', '#'].some(character => value.includes(character)))
+    return false
+  return !Array.from(value).some((character) => {
+    const code = character.codePointAt(0) ?? 0
+    return code <= 31 || code === 127
+  })
+}
+
+function normalizeCount(value) {
+  const count = Number(value)
+  return Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0
+}
+
+async function getMomentKey(momentPath) {
+  const bytes = new TextEncoder().encode(momentPath)
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  const hex = Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, '0')).join('')
+  return `moment_${hex}`
+}
+
+function getStore() {
+  if (typeof moments_like === 'undefined')
+    throw new Error('The moments_like KV binding is not configured')
+  return moments_like
+}
+
+export async function onRequestGet({ request }) {
+  try {
+    const ids = new URL(request.url).searchParams.get('ids')?.split(',').filter(Boolean) ?? []
+    const uniqueIds = [...new Set(ids)]
+
+    if (uniqueIds.length > 100 || uniqueIds.some(id => !isMomentPath(id)))
+      return json({ error: 'Invalid moment ids' }, 400)
+
+    const store = getStore()
+    const entries = await Promise.all(uniqueIds.map(async (momentId) => {
+      const value = await store.get(await getMomentKey(momentId))
+      return [momentId, normalizeCount(value)]
+    }))
+
+    return json(Object.fromEntries(entries))
+  }
+  catch {
+    return json({ error: 'Moments like are temporarily unavailable' }, 503)
+  }
+}
+
+export async function onRequestPost({ request }) {
+  try {
+    const body = await request.json()
+    const momentId = body?.momentId
+    const action = body?.action
+    if (!isMomentPath(momentId) || (action !== 'like' && action !== 'unlike'))
+      return json({ error: 'Invalid request body' }, 400)
+
+    const store = getStore()
+    const key = await getMomentKey(momentId)
+    const currentCount = normalizeCount(await store.get(key))
+    const count = Math.max(0, currentCount + (action === 'like' ? 1 : -1))
+
+    // EdgeOne KV does not expose an atomic increment/decrement API. This
+    // read-modify-write counter is intentionally lightweight and eventually consistent.
+    await store.put(key, String(count))
+    return json({ count })
+  }
+  catch {
+    return json({ error: 'Moments like are temporarily unavailable' }, 503)
+  }
+}

--- a/demo/yun/valaxy.config.ts
+++ b/demo/yun/valaxy.config.ts
@@ -99,8 +99,8 @@ export default defineValaxyConfig<ThemeConfig>({
     addonMoments({
       title: '小随想',
       description: '记录生活里的小事',
-      initialCount: 10,
-      batchSize: 10,
+      initialCount: 5,
+      batchSize: 5,
       likes: {
         enabled: true,
         endpoint: '/api/moments-like',

--- a/demo/yun/valaxy.config.ts
+++ b/demo/yun/valaxy.config.ts
@@ -97,10 +97,14 @@ export default defineValaxyConfig<ThemeConfig>({
     addonComponents(),
     addonGirls(),
     addonMoments({
-      batchSize: 2,
-      description: '记录生活里的小事',
-      initialCount: 2,
       title: '小随想',
+      description: '记录生活里的小事',
+      initialCount: 10,
+      batchSize: 10,
+      likes: {
+        enabled: true,
+        endpoint: '/api/moments-like',
+      },
     }),
 
     // comments

--- a/packages/valaxy-addon-moments/README.md
+++ b/packages/valaxy-addon-moments/README.md
@@ -46,6 +46,12 @@ export default defineValaxyConfig({
 })
 ```
 
+`initialCount` controls how many moments are rendered on the initial visit, and
+`batchSize` controls how many additional moments each **Load more** action
+reveals. Both default to `10`. These options only control progressive rendering;
+when likes are enabled, public counts are fetched for all moments independently
+in batches of up to 100 IDs.
+
 The addon provides `/moments/` automatically. Configure it through
 `addonMoments()` for normal use; no `pages/moments/index.md` file is required.
 

--- a/packages/valaxy-addon-moments/README.md
+++ b/packages/valaxy-addon-moments/README.md
@@ -12,6 +12,7 @@ A theme-independent Markdown moments timeline addon for [Valaxy](https://valaxy.
 - Deletes draft and hidden moment routes before production route files are generated.
 - Uses the site's configured timezone, or UTC when no timezone is configured, so SSG and hydration remain deterministic.
 - Uses Valaxy's configured Markdown-it renderer and syntax highlighting for aggregated content.
+- Optionally reads shared like counts from a configurable HTTP endpoint while keeping only the current browser's liked state in `localStorage`.
 
 The aggregated timeline renders trusted author Markdown as HTML. Vue components, encrypted content, and other transforms that require Vue SFC compilation should remain on normal standalone pages.
 
@@ -36,12 +37,21 @@ export default defineValaxyConfig({
       description: 'Small things worth remembering',
       initialCount: 10,
       batchSize: 10,
+      likes: {
+        enabled: true,
+        endpoint: '/api/moments-like',
+      },
     }),
   ],
 })
 ```
 
-The addon provides `/moments/` automatically. A site may override it with `pages/moments/index.md`:
+The addon provides `/moments/` automatically. Configure it through
+`addonMoments()` for normal use; no `pages/moments/index.md` file is required.
+
+A site may still override the default entry with `pages/moments/index.md` when
+it needs entry-page Markdown or page-specific frontmatter. Values under the
+page's `moments` field take precedence over matching `addonMoments()` options.
 
 ```md
 ---
@@ -50,8 +60,28 @@ description: Small things worth remembering
 moments:
   initialCount: 10
   batchSize: 10
+  likes:
+    enabled: true
+    endpoint: /api/moments-like
 ---
 ```
+
+Because the addon already supplies the same route, the current route scanner
+may print a duplicate-route notice during a build. Valaxy's file priority still
+selects the entry from the user directory. Prefer `addonMoments()` when no
+custom entry content is needed.
+
+Likes are disabled by default. When enabled, the addon batches public count
+requests, updates the button optimistically, and rolls the UI back when the API
+fails. The browser writes its local liked state only after a successful update.
+
+The endpoint is provider-independent. It must support `GET
+/api/moments-like?ids=id1,id2` and `POST /api/moments-like` with `{ momentId,
+action }`. The EdgeOne KV example lives in
+[`demo/yun/edge-functions`](../../demo/yun/edge-functions). Other providers may
+implement the same contract with their own serverless storage. This lightweight
+design does not provide user identity, abuse prevention, or transactionally
+exact counters.
 
 ## Write a moment
 

--- a/packages/valaxy-addon-moments/README.md
+++ b/packages/valaxy-addon-moments/README.md
@@ -75,9 +75,47 @@ Likes are disabled by default. When enabled, the addon batches public count
 requests, updates the button optimistically, and rolls the UI back when the API
 fails. The browser writes its local liked state only after a successful update.
 
-The endpoint is provider-independent. It must support `GET
-/api/moments-like?ids=id1,id2` and `POST /api/moments-like` with `{ momentId,
-action }`. The EdgeOne KV example lives in
+### Likes endpoint contract
+
+The endpoint is provider-independent. A successful response must have a 2xx
+status and a JSON body matching the following contract.
+
+`GET /api/moments-like?ids=id1,id2` returns a map from every requested moment ID
+to its public count:
+
+```json
+{
+  "id1": 12,
+  "id2": 5
+}
+```
+
+Missing or invalid values in an otherwise valid GET map are displayed as `0`.
+Finite counts are floored to integers and negative counts are clamped to `0`.
+
+`POST /api/moments-like` accepts one of these JSON bodies:
+
+```json
+{ "momentId": "id1", "action": "like" }
+```
+
+```json
+{ "momentId": "id1", "action": "unlike" }
+```
+
+It returns the updated public count:
+
+```json
+{ "count": 13 }
+```
+
+The POST `count` must be a finite numeric value. A missing or invalid `count`,
+an empty or malformed JSON body (including a `204` response), or any non-2xx
+status is treated as a request failure. The client then rolls back the
+optimistic update and does not change `localStorage`. A failed GET leaves the
+moments page usable without replacing its current counts.
+
+The EdgeOne KV example lives in
 [`demo/yun/edge-functions`](../../demo/yun/edge-functions). Other providers may
 implement the same contract with their own serverless storage. This lightweight
 design does not provide user identity, abuse prevention, or transactionally

--- a/packages/valaxy-addon-moments/README.zh-CN.md
+++ b/packages/valaxy-addon-moments/README.zh-CN.md
@@ -67,7 +67,40 @@ moments:
 
 点赞默认关闭。启用后，插件会批量读取公共点赞数，并在点击时乐观更新按钮。接口请求失败会回滚界面，只有请求成功后才会保存当前浏览器的点赞状态。
 
-点赞接口不绑定托管平台。接口需要支持 `GET /api/moments-like?ids=id1,id2`，以及接收 `{ momentId, action }` 的 `POST /api/moments-like`。仓库在 [`demo/yun/edge-functions`](../../demo/yun/edge-functions) 中提供了 EdgeOne KV 示例，其他平台可以使用自己的函数和存储实现相同接口。这个轻量方案不包含用户身份、防刷或严格事务计数。
+### 点赞接口契约
+
+点赞接口不绑定托管平台。成功响应必须返回 2xx 状态码，并提供符合以下契约的 JSON 响应体。
+
+`GET /api/moments-like?ids=id1,id2` 返回从每个请求 moment ID 到公共点赞数的映射：
+
+```json
+{
+  "id1": 12,
+  "id2": 5
+}
+```
+
+如果 GET 返回了合法映射，但某个值缺失或无效，客户端会将该项显示为 `0`。有限计数会向下取整，负数会限制为 `0`。
+
+`POST /api/moments-like` 接收以下两种 JSON 请求体之一：
+
+```json
+{ "momentId": "id1", "action": "like" }
+```
+
+```json
+{ "momentId": "id1", "action": "unlike" }
+```
+
+接口返回更新后的公共点赞数：
+
+```json
+{ "count": 13 }
+```
+
+POST 响应中的 `count` 必须是可转换为有限数字的值。`count` 缺失或无效、JSON 响应体为空或格式错误（包括 `204` 响应），以及任何非 2xx 状态都会被视为请求失败。客户端会回滚乐观更新，并且不会修改 `localStorage`。GET 请求失败不会影响 moments 页面，也不会替换当前计数。
+
+仓库在 [`demo/yun/edge-functions`](../../demo/yun/edge-functions) 中提供了 EdgeOne KV 示例，其他平台可以使用自己的函数和存储实现相同接口。这个轻量方案不包含用户身份、防刷或严格事务计数。
 
 ## 编写动态
 

--- a/packages/valaxy-addon-moments/README.zh-CN.md
+++ b/packages/valaxy-addon-moments/README.zh-CN.md
@@ -46,6 +46,8 @@ export default defineValaxyConfig({
 })
 ```
 
+`initialCount` 控制首次访问时渲染的动态数量，`batchSize` 控制每次点击“加载更多”时追加的动态数量，两者默认值均为 `10`。它们只控制渐进渲染；启用点赞后，客户端仍会独立获取全部动态的公共点赞数，每批最多请求 100 个 ID。
+
 插件会自动提供 `/moments/`，推荐直接在 `addonMoments()` 中完成设置。普通站点不需要创建 `pages/moments/index.md`。
 
 站点仍可用 `pages/moments/index.md` 覆盖默认入口，适合需要编写入口页 Markdown 或单独设置 Frontmatter 的情况。页面中填写的 `moments` 选项优先于 `addonMoments()` 中的同名选项。

--- a/packages/valaxy-addon-moments/README.zh-CN.md
+++ b/packages/valaxy-addon-moments/README.zh-CN.md
@@ -12,6 +12,7 @@
 - 在生成生产路由前删除草稿和隐藏动态。
 - 使用站点配置的时区；未配置时固定使用 UTC，避免 SSG 与 hydration 结果不一致。
 - 聚合正文使用 Valaxy 配置的 Markdown-it 渲染器及代码高亮。
+- 可通过自定义 HTTP 接口读取公共点赞数，`localStorage` 只保存当前浏览器是否点过赞。
 
 时间线通过 HTML 展示站点作者可信的 Markdown。依赖 Vue SFC 编译的自定义组件、加密内容等能力应放在普通独立页面中。
 
@@ -36,12 +37,18 @@ export default defineValaxyConfig({
       description: '记录生活里的小事',
       initialCount: 10,
       batchSize: 10,
+      likes: {
+        enabled: true,
+        endpoint: '/api/moments-like',
+      },
     }),
   ],
 })
 ```
 
-插件会自动提供 `/moments/`。站点也可以用 `pages/moments/index.md` 覆盖入口：
+插件会自动提供 `/moments/`，推荐直接在 `addonMoments()` 中完成设置。普通站点不需要创建 `pages/moments/index.md`。
+
+站点仍可用 `pages/moments/index.md` 覆盖默认入口，适合需要编写入口页 Markdown 或单独设置 Frontmatter 的情况。页面中填写的 `moments` 选项优先于 `addonMoments()` 中的同名选项。
 
 ```md
 ---
@@ -50,8 +57,17 @@ description: 记录生活里的小事
 moments:
   initialCount: 10
   batchSize: 10
+  likes:
+    enabled: true
+    endpoint: /api/moments-like
 ---
 ```
+
+由于插件本身已经提供同一路由，当前路由扫描器可能在构建时显示同路由提示。用户目录中的入口页仍会按 Valaxy 的文件优先级生效。没有自定义入口内容时，直接使用 `addonMoments()` 配置即可。
+
+点赞默认关闭。启用后，插件会批量读取公共点赞数，并在点击时乐观更新按钮。接口请求失败会回滚界面，只有请求成功后才会保存当前浏览器的点赞状态。
+
+点赞接口不绑定托管平台。接口需要支持 `GET /api/moments-like?ids=id1,id2`，以及接收 `{ momentId, action }` 的 `POST /api/moments-like`。仓库在 [`demo/yun/edge-functions`](../../demo/yun/edge-functions) 中提供了 EdgeOne KV 示例，其他平台可以使用自己的函数和存储实现相同接口。这个轻量方案不包含用户身份、防刷或严格事务计数。
 
 ## 编写动态
 

--- a/packages/valaxy-addon-moments/client/index.ts
+++ b/packages/valaxy-addon-moments/client/index.ts
@@ -1,5 +1,7 @@
 export * from './data'
+export * from './likes'
 export * from './options'
 export * from './time'
 export * from './useMoments'
+export * from './useMomentsLike'
 export * from './useProgressiveCount'

--- a/packages/valaxy-addon-moments/client/likes.ts
+++ b/packages/valaxy-addon-moments/client/likes.ts
@@ -1,0 +1,100 @@
+export type MomentLikeAction = 'like' | 'unlike'
+
+export const DEFAULT_MOMENTS_LIKE_ENDPOINT = '/api/moments-like'
+export const MOMENTS_LIKE_STORAGE_KEY = 'valaxy:moments-like:v1'
+
+const MAX_IDS_PER_REQUEST = 100
+
+export function normalizeMomentLikeCount(value: unknown) {
+  const count = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0
+}
+
+function uniqueMomentIds(ids: readonly string[]) {
+  return [...new Set(ids.filter(Boolean))]
+}
+
+function withMomentIds(endpoint: string, ids: readonly string[]) {
+  const separator = endpoint.includes('?') ? '&' : '?'
+  return `${endpoint}${separator}ids=${ids.map(encodeURIComponent).join(',')}`
+}
+
+export async function fetchMomentLikeCounts(
+  endpoint: string,
+  ids: readonly string[],
+  fetcher: typeof fetch = fetch,
+) {
+  const uniqueIds = uniqueMomentIds(ids)
+  const counts: Record<string, number> = Object.fromEntries(uniqueIds.map(id => [id, 0]))
+
+  for (let offset = 0; offset < uniqueIds.length; offset += MAX_IDS_PER_REQUEST) {
+    const batch = uniqueIds.slice(offset, offset + MAX_IDS_PER_REQUEST)
+    const response = await fetcher(withMomentIds(endpoint, batch), {
+      headers: { Accept: 'application/json' },
+      method: 'GET',
+    })
+    if (!response.ok)
+      throw new Error(`Unable to load moments like (${response.status})`)
+
+    const data: unknown = await response.json()
+    if (!data || typeof data !== 'object' || Array.isArray(data))
+      throw new TypeError('Invalid moments like response')
+
+    for (const id of batch)
+      counts[id] = normalizeMomentLikeCount((data as Record<string, unknown>)[id])
+  }
+
+  return counts
+}
+
+export async function submitMomentLike(
+  endpoint: string,
+  momentId: string,
+  action: MomentLikeAction,
+  fetcher: typeof fetch = fetch,
+) {
+  const response = await fetcher(endpoint, {
+    body: JSON.stringify({ action, momentId }),
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+  })
+  if (!response.ok)
+    throw new Error(`Unable to update moment like (${response.status})`)
+
+  const data: unknown = await response.json()
+  if (!data || typeof data !== 'object' || Array.isArray(data) || !('count' in data))
+    throw new TypeError('Invalid moment like response')
+
+  return normalizeMomentLikeCount((data as Record<string, unknown>).count)
+}
+
+export function readLikedMomentIds(
+  storage: Pick<Storage, 'getItem'>,
+  key = MOMENTS_LIKE_STORAGE_KEY,
+) {
+  try {
+    const value: unknown = JSON.parse(storage.getItem(key) || '[]')
+    if (!Array.isArray(value))
+      return new Set<string>()
+    return new Set(value.filter((id): id is string => typeof id === 'string' && id.startsWith('/moments/')))
+  }
+  catch {
+    return new Set<string>()
+  }
+}
+
+export function writeLikedMomentIds(
+  storage: Pick<Storage, 'setItem'>,
+  ids: ReadonlySet<string>,
+  key = MOMENTS_LIKE_STORAGE_KEY,
+) {
+  try {
+    storage.setItem(key, JSON.stringify([...ids].sort()))
+  }
+  catch {
+    // Likes still work when localStorage is unavailable; only persistence is lost.
+  }
+}

--- a/packages/valaxy-addon-moments/client/likes.ts
+++ b/packages/valaxy-addon-moments/client/likes.ts
@@ -10,6 +10,17 @@ export function normalizeMomentLikeCount(value: unknown) {
   return Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0
 }
 
+function parseMomentLikeCount(value: unknown) {
+  if (typeof value !== 'number' && (typeof value !== 'string' || !value.trim()))
+    throw new TypeError('Invalid moment like count')
+
+  const count = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(count))
+    throw new TypeError('Invalid moment like count')
+
+  return normalizeMomentLikeCount(count)
+}
+
 function uniqueMomentIds(ids: readonly string[]) {
   return [...new Set(ids.filter(Boolean))]
 }
@@ -23,6 +34,7 @@ export async function fetchMomentLikeCounts(
   endpoint: string,
   ids: readonly string[],
   fetcher: typeof fetch = fetch,
+  signal?: AbortSignal,
 ) {
   const uniqueIds = uniqueMomentIds(ids)
   const counts: Record<string, number> = Object.fromEntries(uniqueIds.map(id => [id, 0]))
@@ -32,6 +44,7 @@ export async function fetchMomentLikeCounts(
     const response = await fetcher(withMomentIds(endpoint, batch), {
       headers: { Accept: 'application/json' },
       method: 'GET',
+      signal,
     })
     if (!response.ok)
       throw new Error(`Unable to load moments like (${response.status})`)
@@ -68,7 +81,7 @@ export async function submitMomentLike(
   if (!data || typeof data !== 'object' || Array.isArray(data) || !('count' in data))
     throw new TypeError('Invalid moment like response')
 
-  return normalizeMomentLikeCount((data as Record<string, unknown>).count)
+  return parseMomentLikeCount((data as Record<string, unknown>).count)
 }
 
 export function readLikedMomentIds(

--- a/packages/valaxy-addon-moments/client/useMomentsLike.ts
+++ b/packages/valaxy-addon-moments/client/useMomentsLike.ts
@@ -1,0 +1,119 @@
+import type { MaybeRefOrGetter } from 'vue'
+import { onMounted, readonly, shallowRef, toValue, watch } from 'vue'
+import { fetchMomentLikeCounts, readLikedMomentIds, submitMomentLike, writeLikedMomentIds } from './likes'
+
+export interface UseMomentsLikeOptions {
+  enabled: MaybeRefOrGetter<boolean>
+  endpoint: MaybeRefOrGetter<string>
+  momentIds: MaybeRefOrGetter<readonly string[]>
+}
+
+export function useMomentsLike(options: UseMomentsLikeOptions) {
+  const counts = shallowRef<Record<string, number>>({})
+  const likedIds = shallowRef<Set<string>>(new Set())
+  const pendingIds = shallowRef<Set<string>>(new Set())
+  let confirmedLikedIds = new Set<string>()
+  let mounted = false
+  let refreshVersion = 0
+
+  function replaceSet(target: typeof likedIds, value: Set<string>) {
+    target.value = value
+  }
+
+  async function refresh() {
+    const version = ++refreshVersion
+    if (!mounted || !toValue(options.enabled))
+      return
+
+    const endpoint = toValue(options.endpoint).trim()
+    const ids = toValue(options.momentIds)
+    if (!endpoint || !ids.length) {
+      counts.value = {}
+      return
+    }
+
+    try {
+      const nextCounts = await fetchMomentLikeCounts(endpoint, ids)
+      if (version === refreshVersion)
+        counts.value = nextCounts
+    }
+    catch {
+      // The moments page remains usable when the optional likes API is unavailable.
+    }
+  }
+
+  async function toggle(momentId: string) {
+    if (!mounted || !toValue(options.enabled) || pendingIds.value.has(momentId))
+      return
+
+    const endpoint = toValue(options.endpoint).trim()
+    if (!endpoint)
+      return
+
+    const wasLiked = likedIds.value.has(momentId)
+    const previousCount = counts.value[momentId] ?? 0
+    const action = wasLiked ? 'unlike' : 'like'
+
+    refreshVersion++
+    replaceSet(pendingIds, new Set(pendingIds.value).add(momentId))
+
+    const optimisticLikedIds = new Set(likedIds.value)
+    if (wasLiked)
+      optimisticLikedIds.delete(momentId)
+    else
+      optimisticLikedIds.add(momentId)
+    replaceSet(likedIds, optimisticLikedIds)
+    counts.value = {
+      ...counts.value,
+      [momentId]: Math.max(0, previousCount + (wasLiked ? -1 : 1)),
+    }
+
+    try {
+      const count = await submitMomentLike(endpoint, momentId, action)
+      counts.value = { ...counts.value, [momentId]: count }
+      confirmedLikedIds = new Set(confirmedLikedIds)
+      if (wasLiked)
+        confirmedLikedIds.delete(momentId)
+      else
+        confirmedLikedIds.add(momentId)
+      writeLikedMomentIds(window.localStorage, confirmedLikedIds)
+    }
+    catch {
+      const rolledBackLikedIds = new Set(likedIds.value)
+      if (wasLiked)
+        rolledBackLikedIds.add(momentId)
+      else
+        rolledBackLikedIds.delete(momentId)
+      replaceSet(likedIds, rolledBackLikedIds)
+      counts.value = { ...counts.value, [momentId]: previousCount }
+    }
+    finally {
+      const nextPendingIds = new Set(pendingIds.value)
+      nextPendingIds.delete(momentId)
+      replaceSet(pendingIds, nextPendingIds)
+    }
+  }
+
+  watch(
+    () => [
+      toValue(options.enabled),
+      toValue(options.endpoint),
+      toValue(options.momentIds).join('\u0000'),
+    ] as const,
+    () => void refresh(),
+  )
+
+  onMounted(() => {
+    mounted = true
+    confirmedLikedIds = readLikedMomentIds(window.localStorage)
+    likedIds.value = new Set(confirmedLikedIds)
+    void refresh()
+  })
+
+  return {
+    counts: readonly(counts),
+    isLiked: (momentId: string) => likedIds.value.has(momentId),
+    isPending: (momentId: string) => pendingIds.value.has(momentId),
+    toggle,
+  }
+}

--- a/packages/valaxy-addon-moments/client/useMomentsLike.ts
+++ b/packages/valaxy-addon-moments/client/useMomentsLike.ts
@@ -1,5 +1,5 @@
 import type { MaybeRefOrGetter } from 'vue'
-import { onMounted, readonly, shallowRef, toValue, watch } from 'vue'
+import { onBeforeUnmount, onMounted, readonly, shallowRef, toValue, watch } from 'vue'
 import { fetchMomentLikeCounts, readLikedMomentIds, submitMomentLike, writeLikedMomentIds } from './likes'
 
 export interface UseMomentsLikeOptions {
@@ -15,30 +15,54 @@ export function useMomentsLike(options: UseMomentsLikeOptions) {
   let confirmedLikedIds = new Set<string>()
   let mounted = false
   let refreshVersion = 0
+  let refreshController: AbortController | undefined
+  const mutationRevisions = new Map<string, number>()
 
   function replaceSet(target: typeof likedIds, value: Set<string>) {
     target.value = value
   }
 
+  function markMutation(momentId: string) {
+    mutationRevisions.set(momentId, (mutationRevisions.get(momentId) ?? 0) + 1)
+  }
+
   async function refresh() {
     const version = ++refreshVersion
+    refreshController?.abort()
+    refreshController = undefined
     if (!mounted || !toValue(options.enabled))
       return
 
     const endpoint = toValue(options.endpoint).trim()
-    const ids = toValue(options.momentIds)
+    const ids = [...toValue(options.momentIds)]
     if (!endpoint || !ids.length) {
       counts.value = {}
       return
     }
 
+    const controller = new AbortController()
+    const revisions = new Map(ids.map(id => [id, mutationRevisions.get(id) ?? 0]))
+    refreshController = controller
+
     try {
-      const nextCounts = await fetchMomentLikeCounts(endpoint, ids)
-      if (version === refreshVersion)
-        counts.value = nextCounts
+      const nextCounts = await fetchMomentLikeCounts(endpoint, ids, fetch, controller.signal)
+      if (version !== refreshVersion || controller.signal.aborted || !mounted)
+        return
+
+      const mergedCounts = { ...counts.value }
+      for (const [momentId, count] of Object.entries(nextCounts)) {
+        const revisionUnchanged = (mutationRevisions.get(momentId) ?? 0) === revisions.get(momentId)
+        if (revisionUnchanged && !pendingIds.value.has(momentId))
+          mergedCounts[momentId] = count
+      }
+      counts.value = mergedCounts
     }
     catch {
       // The moments page remains usable when the optional likes API is unavailable.
+    }
+    finally {
+      if (refreshController === controller)
+        refreshController = undefined
     }
   }
 
@@ -54,7 +78,7 @@ export function useMomentsLike(options: UseMomentsLikeOptions) {
     const previousCount = counts.value[momentId] ?? 0
     const action = wasLiked ? 'unlike' : 'like'
 
-    refreshVersion++
+    markMutation(momentId)
     replaceSet(pendingIds, new Set(pendingIds.value).add(momentId))
 
     const optimisticLikedIds = new Set(likedIds.value)
@@ -70,6 +94,7 @@ export function useMomentsLike(options: UseMomentsLikeOptions) {
 
     try {
       const count = await submitMomentLike(endpoint, momentId, action)
+      markMutation(momentId)
       counts.value = { ...counts.value, [momentId]: count }
       confirmedLikedIds = new Set(confirmedLikedIds)
       if (wasLiked)
@@ -79,6 +104,7 @@ export function useMomentsLike(options: UseMomentsLikeOptions) {
       writeLikedMomentIds(window.localStorage, confirmedLikedIds)
     }
     catch {
+      markMutation(momentId)
       const rolledBackLikedIds = new Set(likedIds.value)
       if (wasLiked)
         rolledBackLikedIds.add(momentId)
@@ -108,6 +134,13 @@ export function useMomentsLike(options: UseMomentsLikeOptions) {
     confirmedLikedIds = readLikedMomentIds(window.localStorage)
     likedIds.value = new Set(confirmedLikedIds)
     void refresh()
+  })
+
+  onBeforeUnmount(() => {
+    mounted = false
+    refreshVersion++
+    refreshController?.abort()
+    refreshController = undefined
   })
 
   return {

--- a/packages/valaxy-addon-moments/components/ValaxyMomentCard.vue
+++ b/packages/valaxy-addon-moments/components/ValaxyMomentCard.vue
@@ -5,10 +5,23 @@ import { computed, nextTick, onBeforeUnmount, onMounted, shallowRef, useId, useT
 import { useI18n } from 'vue-i18n'
 import { formatMomentDate, isPinnedMoment, toMomentDateTime } from '../client/time'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   author: MomentsAuthor
+  likeCount?: number
+  likePending?: boolean
+  liked?: boolean
+  likesEnabled?: boolean
   moment: MomentEntry
   timezone: string
+}>(), {
+  likeCount: 0,
+  likePending: false,
+  liked: false,
+  likesEnabled: false,
+})
+
+const emit = defineEmits<{
+  toggleLike: []
 }>()
 
 const { t } = useI18n()
@@ -163,11 +176,28 @@ const imageGridClass = computed(() => `valaxy-moment-images-${props.moment.image
       >
     </div>
 
-    <footer v-if="moment.location" class="valaxy-moment-footer">
-      <span class="valaxy-moment-location">
+    <footer v-if="moment.location || likesEnabled" class="valaxy-moment-footer">
+      <span v-if="moment.location" class="valaxy-moment-location">
         <span class="i-ri-map-pin-2-line" aria-hidden="true" />
         <span>{{ moment.location }}</span>
       </span>
+      <button
+        v-if="likesEnabled"
+        class="valaxy-moment-like"
+        :class="{ 'is-liked': liked }"
+        type="button"
+        :aria-label="t(liked ? 'addon.moments.unlike' : 'addon.moments.like')"
+        :aria-pressed="liked"
+        :disabled="likePending"
+        @click="emit('toggleLike')"
+      >
+        <span
+          class="valaxy-moment-like-icon"
+          :class="liked ? 'i-ri-heart-3-fill' : 'i-ri-heart-3-line'"
+          aria-hidden="true"
+        />
+        <span>{{ likeCount }}</span>
+      </button>
     </footer>
   </article>
 </template>
@@ -353,6 +383,8 @@ const imageGridClass = computed(() => `valaxy-moment-images-${props.moment.image
 .valaxy-moment-footer {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
   margin-top: 0.9rem;
 }
 
@@ -360,6 +392,56 @@ const imageGridClass = computed(() => `valaxy-moment-images-${props.moment.image
   display: inline-flex;
   gap: 0.3rem;
   align-items: center;
+}
+
+.valaxy-moment-like {
+  display: inline-flex;
+  gap: 0.3rem;
+  align-items: center;
+  min-width: 2.5rem;
+  padding: 0.25rem 0.5rem;
+  margin-left: auto;
+  color: var(--va-c-text-2, #74777d);
+  font: inherit;
+  font-size: 0.84rem;
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.valaxy-moment-like:hover,
+.valaxy-moment-like.is-liked {
+  color: var(--va-c-danger, #ef476f);
+  background: color-mix(in srgb, currentcolor 8%, transparent);
+}
+
+.valaxy-moment-like:focus-visible {
+  outline: 2px solid currentcolor;
+  outline-offset: 2px;
+}
+
+.valaxy-moment-like:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.valaxy-moment-like-icon {
+  display: block;
+  flex: 0 0 auto;
+  font-size: 1.15rem;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .valaxy-moment-like.is-liked .valaxy-moment-like-icon {
+    animation: valaxy-moment-like-pop 220ms ease-out;
+  }
+}
+
+@keyframes valaxy-moment-like-pop {
+  50% {
+    transform: scale(1.25);
+  }
 }
 
 .sr-only {

--- a/packages/valaxy-addon-moments/components/ValaxyMoments.vue
+++ b/packages/valaxy-addon-moments/components/ValaxyMoments.vue
@@ -3,7 +3,7 @@ import type { MomentsAuthor, MomentsPageFrontmatter } from '../types'
 import { useFrontmatter, useSiteConfig, useValaxyI18n } from 'valaxy'
 import { computed, nextTick, onBeforeUnmount, onMounted, useId } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { getMomentMonth, getMomentMonthAnchorTargets, groupMomentsByYear, partitionPinnedMoments, useMoments, useMomentsConfig, useMomentsProgressiveCount } from '../client'
+import { DEFAULT_MOMENTS_LIKE_ENDPOINT, getMomentMonth, getMomentMonthAnchorTargets, groupMomentsByYear, partitionPinnedMoments, useMoments, useMomentsConfig, useMomentsLike, useMomentsProgressiveCount } from '../client'
 import ValaxyMomentCard from './ValaxyMomentCard.vue'
 
 const props = defineProps<{
@@ -37,6 +37,8 @@ const title = computed(() => localizeText(props.title ?? frontmatter.value.title
 const description = computed(() => localizeText(props.description ?? frontmatter.value.description ?? addon.value?.options?.description))
 const initialCount = computed(() => props.initialCount ?? options.value?.initialCount ?? addon.value?.options?.initialCount ?? 10)
 const batchSize = computed(() => props.batchSize ?? options.value?.batchSize ?? addon.value?.options?.batchSize ?? 10)
+const likesEnabled = computed(() => options.value?.likes?.enabled ?? addon.value?.options?.likes?.enabled ?? false)
+const likesEndpoint = computed(() => options.value?.likes?.endpoint ?? addon.value?.options?.likes?.endpoint ?? DEFAULT_MOMENTS_LIKE_ENDPOINT)
 const timezone = computed(() => siteConfig.value.timezone || 'UTC')
 const author = computed<MomentsAuthor>(() => {
   const rawName = options.value?.author?.name || addon.value?.options?.author?.name || siteConfig.value.author.name
@@ -56,6 +58,11 @@ const partitionedMoments = computed(() => partitionPinnedMoments(visibleMoments.
 const pinnedMoments = computed(() => partitionedMoments.value.pinned)
 const groupedMoments = computed(() => groupMomentsByYear(partitionedMoments.value.regular, timezone.value))
 const monthAnchorTargets = computed(() => getMomentMonthAnchorTargets(moments.value, timezone.value))
+const { counts: likeCounts, isLiked, isPending: isLikePending, toggle: toggleLike } = useMomentsLike({
+  enabled: likesEnabled,
+  endpoint: likesEndpoint,
+  momentIds: () => moments.value.map(moment => moment.path),
+})
 
 function getMonthAnchorId(moment: (typeof moments.value)[number]) {
   const anchor = getMomentMonth(moment.date, timezone.value).anchor
@@ -100,8 +107,13 @@ onBeforeUnmount(() => {
           <ValaxyMomentCard
             :id="getMonthAnchorId(moment)"
             :author="author"
+            :like-count="likeCounts[moment.path] ?? 0"
+            :like-pending="isLikePending(moment.path)"
+            :liked="isLiked(moment.path)"
+            :likes-enabled="likesEnabled"
             :moment="moment"
             :timezone="timezone"
+            @toggle-like="toggleLike(moment.path)"
           />
         </div>
       </div>
@@ -116,8 +128,13 @@ onBeforeUnmount(() => {
             :id="getMonthAnchorId(moment)"
             :key="moment.path"
             :author="author"
+            :like-count="likeCounts[moment.path] ?? 0"
+            :like-pending="isLikePending(moment.path)"
+            :liked="isLiked(moment.path)"
+            :likes-enabled="likesEnabled"
             :moment="moment"
             :timezone="timezone"
+            @toggle-like="toggleLike(moment.path)"
           />
         </section>
       </template>

--- a/packages/valaxy-addon-moments/locales/en.yml
+++ b/packages/valaxy-addon-moments/locales/en.yml
@@ -6,7 +6,9 @@ addon:
     expand: Expand
     image: Moment image {index}
     images: '{count} attached images'
+    like: Like this moment
     more: Load more ({count})
     month: month
     pinned: Pinned
     timeline: Timeline
+    unlike: Unlike this moment

--- a/packages/valaxy-addon-moments/locales/zh-CN.yml
+++ b/packages/valaxy-addon-moments/locales/zh-CN.yml
@@ -6,7 +6,9 @@ addon:
     expand: 展开
     image: 动态图片 {index}
     images: 共 {count} 张图片
+    like: 点赞动态
     more: 加载更多（剩余 {count} 条）
     month: 月
     pinned: 置顶
     timeline: 时间线
+    unlike: 取消点赞

--- a/packages/valaxy-addon-moments/node/index.ts
+++ b/packages/valaxy-addon-moments/node/index.ts
@@ -128,6 +128,7 @@ export const addonMoments = defineValaxyAddon<MomentsOptions>((options = {}) => 
             ...(options.author === undefined ? {} : { author: options.author }),
             ...(options.initialCount === undefined ? {} : { initialCount: options.initialCount }),
             ...(options.batchSize === undefined ? {} : { batchSize: options.batchSize }),
+            ...(options.likes === undefined ? {} : { likes: options.likes }),
             ...pageOptions,
           },
         },

--- a/packages/valaxy-addon-moments/test/moments.test.ts
+++ b/packages/valaxy-addon-moments/test/moments.test.ts
@@ -72,6 +72,14 @@ describe('moments like', () => {
     expect(JSON.parse(requestBody)).toEqual({ action: 'like', momentId: '/moments/a' })
   })
 
+  it('rejects an invalid POST count while clamping a negative count to zero', async () => {
+    const respondWith = (body: unknown): typeof fetch => async () => new Response(JSON.stringify(body))
+
+    await expect(submitMomentLike('/api/moments-like', '/moments/a', 'like', respondWith({ count: 'invalid' }))).rejects.toThrow(TypeError)
+    await expect(submitMomentLike('/api/moments-like', '/moments/a', 'like', respondWith({}))).rejects.toThrow(TypeError)
+    await expect(submitMomentLike('/api/moments-like', '/moments/a', 'like', respondWith({ count: -2 }))).resolves.toBe(0)
+  })
+
   it('stores only valid locally liked moment paths', () => {
     let stored = JSON.stringify(['/moments/b', '/posts/not-a-moment', 1])
     const storage = {

--- a/packages/valaxy-addon-moments/test/moments.test.ts
+++ b/packages/valaxy-addon-moments/test/moments.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, expectTypeOf, it } from 'vitest'
 import { nextTick, shallowRef } from 'vue'
 import { createMarkdownRenderer } from '../../valaxy/node/plugins/markdown'
 import { normalizeMomentImages, normalizeMomentRoutes } from '../client/data'
+import { fetchMomentLikeCounts, readLikedMomentIds, submitMomentLike, writeLikedMomentIds } from '../client/likes'
 import { formatMomentDate, getMomentMonth, getMomentMonthAnchorTargets, groupMomentsByYear, partitionPinnedMoments } from '../client/time'
 import { useMomentsProgressiveCount } from '../client/useProgressiveCount'
 import { renderMomentMarkdown, shouldExcludeMoment } from '../node'
@@ -37,7 +38,50 @@ describe('moments page frontmatter', () => {
   it('keeps title and description at the page frontmatter level', () => {
     type PageMomentsOptions = NonNullable<MomentsPageFrontmatter['moments']>
 
-    expectTypeOf<PageMomentsOptions>().toEqualTypeOf<Pick<MomentsOptions, 'author' | 'batchSize' | 'initialCount'>>()
+    expectTypeOf<PageMomentsOptions>().toEqualTypeOf<Pick<MomentsOptions, 'author' | 'batchSize' | 'initialCount' | 'likes'>>()
+  })
+})
+
+describe('moments like', () => {
+  it('loads public counts for multiple moments in one request and normalizes values', async () => {
+    const requests: string[] = []
+    const fetcher: typeof fetch = async (input) => {
+      requests.push(String(input))
+      return new Response(JSON.stringify({
+        '/moments/a': 12,
+        '/moments/b': -3,
+      }))
+    }
+
+    await expect(fetchMomentLikeCounts('/api/moments-like', ['/moments/a', '/moments/b'], fetcher)).resolves.toEqual({
+      '/moments/a': 12,
+      '/moments/b': 0,
+    })
+    expect(requests).toHaveLength(1)
+    expect(requests[0]).toContain('ids=%2Fmoments%2Fa,%2Fmoments%2Fb')
+  })
+
+  it('posts a like action and uses the server count', async () => {
+    let requestBody = ''
+    const fetcher: typeof fetch = async (_input, init) => {
+      requestBody = String(init?.body)
+      return new Response(JSON.stringify({ count: 8 }))
+    }
+
+    await expect(submitMomentLike('/api/moments-like', '/moments/a', 'like', fetcher)).resolves.toBe(8)
+    expect(JSON.parse(requestBody)).toEqual({ action: 'like', momentId: '/moments/a' })
+  })
+
+  it('stores only valid locally liked moment paths', () => {
+    let stored = JSON.stringify(['/moments/b', '/posts/not-a-moment', 1])
+    const storage = {
+      getItem: () => stored,
+      setItem: (_key: string, value: string) => stored = value,
+    }
+
+    expect([...readLikedMomentIds(storage)]).toEqual(['/moments/b'])
+    writeLikedMomentIds(storage, new Set(['/moments/b', '/moments/a']))
+    expect(JSON.parse(stored)).toEqual(['/moments/a', '/moments/b'])
   })
 })
 

--- a/packages/valaxy-addon-moments/test/useMomentsLike.test.ts
+++ b/packages/valaxy-addon-moments/test/useMomentsLike.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import type { MaybeRefOrGetter } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, shallowRef } from 'vue'
+import { useMomentsLike } from '../client/useMomentsLike'
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function mountMomentsLike(momentIds: MaybeRefOrGetter<readonly string[]>) {
+  let likes!: ReturnType<typeof useMomentsLike>
+  const app = createApp({
+    setup() {
+      likes = useMomentsLike({
+        enabled: true,
+        endpoint: '/api/moments-like',
+        momentIds,
+      })
+      return () => null
+    },
+  })
+  app.mount(document.createElement('div'))
+  return { app, likes }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  window.localStorage.clear()
+})
+
+describe('useMomentsLike', () => {
+  it('merges a delayed GET without overwriting a moment updated by POST', async () => {
+    const getResponse = deferred<Response>()
+    const fetcher = vi.fn<typeof fetch>((_input, init) => {
+      if (init?.method === 'POST')
+        return Promise.resolve(new Response(JSON.stringify({ count: 13 })))
+      return getResponse.promise
+    })
+    vi.stubGlobal('fetch', fetcher)
+
+    const { app, likes } = mountMomentsLike(['/moments/a', '/moments/b'])
+    await vi.waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1))
+
+    await likes.toggle('/moments/a')
+    expect(likes.counts.value['/moments/a']).toBe(13)
+
+    getResponse.resolve(new Response(JSON.stringify({
+      '/moments/a': 12,
+      '/moments/b': 7,
+    })))
+
+    await vi.waitFor(() => expect(likes.counts.value['/moments/b']).toBe(7))
+    expect(likes.counts.value['/moments/a']).toBe(13)
+    app.unmount()
+  })
+
+  it('aborts a pending GET when its component scope is destroyed', async () => {
+    let requestSignal: AbortSignal | undefined
+    const fetcher = vi.fn<typeof fetch>((_input, init) => new Promise<Response>((_resolve, reject) => {
+      requestSignal = init?.signal ?? undefined
+      requestSignal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true })
+    }))
+    vi.stubGlobal('fetch', fetcher)
+
+    const { app } = mountMomentsLike(['/moments/a'])
+    await vi.waitFor(() => expect(requestSignal).toBeDefined())
+    app.unmount()
+
+    expect(requestSignal?.aborted).toBe(true)
+  })
+
+  it('aborts and discards a stale GET when the moment IDs change', async () => {
+    const momentIds = shallowRef<readonly string[]>(['/moments/a'])
+    const firstResponse = deferred<Response>()
+    const staleJsonRead = deferred<boolean>()
+    const requestSignals: AbortSignal[] = []
+    const fetcher = vi.fn<typeof fetch>((_input, init) => {
+      requestSignals.push(init?.signal as AbortSignal)
+      if (requestSignals.length === 1)
+        return firstResponse.promise
+      return Promise.resolve(new Response(JSON.stringify({ '/moments/b': 4 })))
+    })
+    vi.stubGlobal('fetch', fetcher)
+
+    const { app, likes } = mountMomentsLike(momentIds)
+    await vi.waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1))
+
+    momentIds.value = ['/moments/b']
+    await vi.waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2))
+    expect(requestSignals[0].aborted).toBe(true)
+    await vi.waitFor(() => expect(likes.counts.value['/moments/b']).toBe(4))
+
+    firstResponse.resolve({
+      json: async () => {
+        staleJsonRead.resolve(true)
+        return { '/moments/a': 9 }
+      },
+      ok: true,
+      status: 200,
+    } as Response)
+    await staleJsonRead.promise
+    await Promise.resolve()
+    expect(likes.counts.value['/moments/a']).toBeUndefined()
+    app.unmount()
+  })
+})

--- a/packages/valaxy-addon-moments/types/index.ts
+++ b/packages/valaxy-addon-moments/types/index.ts
@@ -12,8 +12,10 @@ export interface MomentsLikeOptions {
 
 export interface MomentsOptions {
   author?: MomentsAuthor
+  /** Number of additional moments revealed per "Load more" action. @default 10 */
   batchSize?: number
   description?: string | Record<string, string>
+  /** Number of moments rendered initially. @default 10 */
   initialCount?: number
   likes?: MomentsLikeOptions
   title?: string | Record<string, string>

--- a/packages/valaxy-addon-moments/types/index.ts
+++ b/packages/valaxy-addon-moments/types/index.ts
@@ -3,15 +3,23 @@ export interface MomentsAuthor {
   name?: string
 }
 
+export interface MomentsLikeOptions {
+  /** Enable the shared like count UI. @default false */
+  enabled?: boolean
+  /** HTTP endpoint implementing the moments like API. @default '/api/moments-like' */
+  endpoint?: string
+}
+
 export interface MomentsOptions {
   author?: MomentsAuthor
   batchSize?: number
   description?: string | Record<string, string>
   initialCount?: number
+  likes?: MomentsLikeOptions
   title?: string | Record<string, string>
 }
 
-export type MomentsPageOptions = Pick<MomentsOptions, 'author' | 'batchSize' | 'initialCount'>
+export type MomentsPageOptions = Pick<MomentsOptions, 'author' | 'batchSize' | 'initialCount' | 'likes'>
 
 /** Options read from the `moments` field of `pages/moments/index.md`. */
 export interface MomentsPageFrontmatter {


### PR DESCRIPTION
### Description

#### 为 moments 页面增加可选点赞功能

点赞功能默认关闭，可在 `valaxy.config.ts` 中配置：

```ts [valaxy.config.ts]
import { defineValaxyConfig } from 'valaxy'
import { addonMoments } from 'valaxy-addon-moments'

export default defineValaxyConfig({
  addons: [
    addonMoments({
      title: '小随想',
      description: '记录生活里的小事',
      initialCount: 10,
      batchSize: 10,
      likes: {
        enabled: true,
        endpoint: '/api/moments-like',
      },
    }),
  ],
})
```

点赞默认关闭。启用后，插件会批量读取公共点赞数，并在点击时乐观更新按钮。接口请求失败会回滚界面，只有请求成功后才会保存当前浏览器的点赞状态。

点赞接口不绑定托管平台。接口需要支持 `GET /api/moments-like?ids=id1,id2`，以及接收 `{ momentId, action }` 的 `POST /api/moments-like`。仓库在 [`demo/yun/edge-functions`](../../demo/yun/edge-functions) 中提供了 EdgeOne KV 示例，其他平台可以使用自己的函数和存储实现相同接口。这个轻量方案不包含用户身份、防刷或严格事务计数。