### PR TITLE
feat(cli): support addon commands

### DIFF
--- a/docs/pages/guide/commands/index.md
+++ b/docs/pages/guide/commands/index.md
@@ -113,6 +113,32 @@ and update the date.
 
 - [自定义文章模板](/guide/custom/templates)
 
+### Addon Commands
+
+Enabled addons may provide commands below a package-derived namespace. For example, after configuring `valaxy-addon-moments` with `addonMoments()`:
+
+```bash
+valaxy moments new [title]
+valaxy moments --help
+```
+
+Addon commands are resolved from the current project only when invoked, so the global `valaxy --help` output lists core commands only. An addon cannot override a core command or another enabled addon's command.
+
+Addon authors register subcommands with the experimental `extendCli` hook returned by `defineValaxyAddon`. Valaxy derives the root namespace from the package name and passes a CLI already scoped below it:
+
+```ts
+export const addonMoments = defineValaxyAddon(() => ({
+  name: 'valaxy-addon-moments',
+  extendCli(cli, { userRoot }) {
+    cli.command('new [title]', 'Draft a new moment', () => {}, ({ title }) => {
+      // Create the moment below userRoot.
+    })
+  },
+}))
+```
+
+CLI hooks require the recommended factory/object addon configuration, such as `addonMoments()`. String addon entries do not carry Node hooks.
+
 ## FAQ
 
 

--- a/docs/pages/zh/guide/commands/index.md
+++ b/docs/pages/zh/guide/commands/index.md
@@ -119,6 +119,32 @@ Valaxy SSG 引擎分为三个阶段：
 
 - [自定义文章模板](/zh/guide/custom/templates)
 
+### 插件命令 {#addon-commands}
+
+已启用的插件可以在根据包名生成的命名空间下提供命令。例如，通过 `addonMoments()` 配置 `valaxy-addon-moments` 后：
+
+```bash
+valaxy moments new [title]
+valaxy moments --help
+```
+
+插件命令仅在调用时从当前项目解析，因此全局 `valaxy --help` 只展示核心命令。插件不能覆盖核心命令，也不能与另一个已启用插件的命令重名。
+
+插件作者可通过 `defineValaxyAddon` 返回值中实验性的 `extendCli` 钩子注册子命令。Valaxy 会根据包名生成根命名空间，并传入已经限制在该命名空间下的 CLI：
+
+```ts
+export const addonMoments = defineValaxyAddon(() => ({
+  name: 'valaxy-addon-moments',
+  extendCli(cli, { userRoot }) {
+    cli.command('new [title]', 'Draft a new moment', () => {}, ({ title }) => {
+      // 在 userRoot 下创建动态。
+    })
+  },
+}))
+```
+
+CLI 钩子要求使用推荐的工厂/对象形式配置插件，例如 `addonMoments()`；字符串插件配置不携带 Node 钩子。
+
 ## FAQ {#faq}
 
 ### 控制台开发时日志太少，构建时日志太多？ {#more-logs-when-developing-and-less-when-building}
@@ -152,5 +178,3 @@ Valaxy SSG 引擎分为三个阶段：
   }
 }
 ```
-
-

--- a/packages/valaxy/bin/valaxy.mjs
+++ b/packages/valaxy/bin/valaxy.mjs
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 'use strict'
 
+import process from 'node:process'
 import { run } from '../dist/node/cli/index.mjs'
 
-function main() {
-  run()
+async function main() {
+  await run()
 }
 
-main()
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/packages/valaxy/node/cli/addons.ts
+++ b/packages/valaxy/node/cli/addons.ts
@@ -1,0 +1,137 @@
+import type { Argv } from 'yargs'
+import type { ValaxyAddonExtendCli, ValaxyAddons } from '../types'
+import { isAbsolute } from 'node:path'
+import { resolveValaxyConfig } from '../config'
+
+const ADDON_PACKAGE_PREFIX = 'valaxy-addon-'
+const ADDON_COMMAND_RE = /^[a-z0-9][a-z0-9-]*$/
+
+/** Root commands that addons may not shadow. */
+export const CORE_CLI_COMMANDS = new Set([
+  'addon',
+  'build',
+  'clean',
+  'completion',
+  'debug',
+  'deploy',
+  'dev',
+  'fuse',
+  'help',
+  'llms',
+  'new',
+  'rss',
+  'version',
+])
+
+export interface ResolvedAddonCliExtension {
+  addonName: string
+  commandName: string
+  extendCli: ValaxyAddonExtendCli
+}
+
+function configuredAddonValues(addons: ValaxyAddons = []) {
+  return Array.isArray(addons) ? addons : Object.values(addons)
+}
+
+export function getAddonCommandName(addonName: string) {
+  const packageName = addonName.includes('/')
+    ? addonName.slice(addonName.lastIndexOf('/') + 1)
+    : addonName
+
+  if (!packageName.startsWith(ADDON_PACKAGE_PREFIX)) {
+    throw new Error(
+      `Addon "${addonName}" cannot extend the CLI because its package name does not start with "${ADDON_PACKAGE_PREFIX}".`,
+    )
+  }
+
+  const commandName = packageName.slice(ADDON_PACKAGE_PREFIX.length)
+  if (!ADDON_COMMAND_RE.test(commandName))
+    throw new Error(`Addon "${addonName}" resolves to an invalid CLI command name "${commandName}".`)
+
+  return commandName
+}
+
+export function collectAddonCliExtensions(addons: ValaxyAddons = []) {
+  const extensions: ResolvedAddonCliExtension[] = []
+  const owners = new Map<string, string>()
+
+  for (const addon of configuredAddonValues(addons)) {
+    if (!addon || typeof addon === 'string' || addon.enable === false || typeof addon.extendCli !== 'function')
+      continue
+
+    const commandName = getAddonCommandName(addon.name)
+    if (CORE_CLI_COMMANDS.has(commandName)) {
+      throw new Error(
+        `Addon "${addon.name}" cannot register the reserved Valaxy command "${commandName}".`,
+      )
+    }
+
+    const owner = owners.get(commandName)
+    if (owner) {
+      throw new Error(
+        `Addons "${owner}" and "${addon.name}" both register the Valaxy command "${commandName}".`,
+      )
+    }
+
+    owners.set(commandName, addon.name)
+    extensions.push({
+      addonName: addon.name,
+      commandName,
+      extendCli: addon.extendCli,
+    })
+  }
+
+  return extensions
+}
+
+export async function resolveAddonCliExtensions(userRoot: string) {
+  const { config } = await resolveValaxyConfig({ userRoot })
+  return collectAddonCliExtensions(config?.addons)
+}
+
+export function registerAddonCliExtensions(
+  cli: Argv<object>,
+  extensions: ResolvedAddonCliExtension[],
+  userRoot: string,
+) {
+  for (const extension of extensions) {
+    let scopedCli: Argv<object> | undefined
+
+    cli.command(
+      extension.commandName,
+      `Commands provided by ${extension.addonName}`,
+      (args: Argv<object>) => {
+        const scope = args
+          .usage(`$0 ${extension.commandName} <command>`)
+          .strict()
+          .help()
+        scopedCli = scope
+        extension.extendCli(scope, { userRoot })
+        return scope
+      },
+      () => {
+        scopedCli?.showHelp('log')
+      },
+    )
+  }
+}
+
+export function getRequestedCommand(argv: string[]) {
+  const command = argv[0]
+  return command && !command.startsWith('-') ? command : undefined
+}
+
+export function shouldResolveAddonCli(argv: string[]) {
+  if (argv.some(arg => arg === '--version' || arg === '-v'))
+    return false
+
+  const command = getRequestedCommand(argv)
+  if (!command || CORE_CLI_COMMANDS.has(command))
+    return false
+
+  // An explicit path always selects the default dev command.
+  return command !== '.'
+    && !command.startsWith('./')
+    && !command.startsWith('../')
+    && !isAbsolute(command)
+}

--- a/packages/valaxy/node/cli/index.ts
+++ b/packages/valaxy/node/cli/index.ts
@@ -1,7 +1,7 @@
-// modules
+import type { Argv } from 'yargs'
 import type { ValaxyModule } from '../modules'
+import { resolve } from 'node:path'
 import process from 'node:process'
-
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 
@@ -11,6 +11,7 @@ import { fuseModule } from '../modules/fuse'
 import { llmsModule } from '../modules/llms'
 import { rssModule } from '../modules/rss'
 
+import { registerAddonCliExtensions, resolveAddonCliExtensions, shouldResolveAddonCli } from './addons'
 import { registerBuildCommand } from './build'
 import { registerCleanCommand } from './clean'
 import { registerDebugCommand } from './debug'
@@ -20,21 +21,6 @@ import { registerDevCommand } from './dev'
 import { registerNewCommand } from './new'
 
 export * from './dev'
-export const cli = yargs(hideBin(process.argv))
-  .scriptName('valaxy')
-  .usage('$0 [args]')
-  .version(version)
-  .showHelpOnFail(false)
-  .alias('h', 'help')
-  .alias('v', 'version')
-
-registerDevCommand(cli)
-registerBuildCommand(cli)
-registerNewCommand(cli)
-registerCleanCommand(cli)
-registerDeployCommand(cli)
-registerDebugCommand(cli)
-cli.help()
 
 const modules: ValaxyModule[] = [
   fuseModule,
@@ -42,10 +28,48 @@ const modules: ValaxyModule[] = [
   rssModule,
 ]
 
-modules.forEach((module) => {
-  module.extendCli?.(cli)
-})
+export interface CreateCliOptions {
+  userRoot?: string
+}
 
-export function run() {
-  cli.parse()
+function createCoreCli(argv: string[]) {
+  const cli: Argv<object> = yargs(argv)
+    .scriptName('valaxy')
+    .usage('$0 [args]')
+    .version(version)
+    .showHelpOnFail(false)
+    .alias('h', 'help')
+    .alias('v', 'version')
+
+  registerDevCommand(cli)
+  registerBuildCommand(cli)
+  registerNewCommand(cli)
+  registerCleanCommand(cli)
+  registerDeployCommand(cli)
+  registerDebugCommand(cli)
+
+  modules.forEach((module) => {
+    module.extendCli?.(cli)
+  })
+
+  return cli.help()
+}
+
+export async function createCli(
+  argv: string[] = hideBin(process.argv),
+  options: CreateCliOptions = {},
+) {
+  const cli = createCoreCli(argv)
+  if (!shouldResolveAddonCli(argv))
+    return cli
+
+  const userRoot = resolve(options.userRoot || process.cwd())
+  const extensions = await resolveAddonCliExtensions(userRoot)
+  registerAddonCliExtensions(cli, extensions, userRoot)
+  return cli
+}
+
+export async function run(argv: string[] = hideBin(process.argv), options: CreateCliOptions = {}) {
+  const cli = await createCli(argv, options)
+  await cli.parseAsync()
 }

--- a/packages/valaxy/node/config/addon.ts
+++ b/packages/valaxy/node/config/addon.ts
@@ -1,5 +1,4 @@
-import type { ValaxyAddon } from '../../types'
-import type { ResolvedValaxyOptions, ValaxyAddonResolver, ValaxyNodeConfig } from '../types'
+import type { ResolvedValaxyOptions, ValaxyAddonResolver, ValaxyNodeAddon, ValaxyNodeConfig } from '../types'
 import path from 'node:path'
 import { consola } from 'consola'
 import fs from 'fs-extra'
@@ -7,9 +6,7 @@ import { countPerformanceTime } from '../utils/performance'
 import { mergeValaxyConfig, resolveValaxyConfigFromRoot } from './valaxy'
 
 export function defineValaxyAddon<AddonOptions = object>(
-  addonFunc: (addonOptions?: AddonOptions, valaxyOptions?: ResolvedValaxyOptions) => ValaxyAddon & {
-    setup?: ValaxyAddonResolver['setup']
-  },
+  addonFunc: (addonOptions?: AddonOptions, valaxyOptions?: ResolvedValaxyOptions) => ValaxyNodeAddon,
 ) {
   return addonFunc
 }

--- a/packages/valaxy/node/types/addon.ts
+++ b/packages/valaxy/node/types/addon.ts
@@ -1,6 +1,19 @@
+import type { Argv } from 'yargs'
 import type { DefaultTheme, ValaxyAddon } from '../../types'
 import type { ValaxyNode, ValaxyNodeConfig } from './config'
 import type { ResolvedValaxyOptions } from './options'
+
+export interface ValaxyAddonCliContext {
+  /** The Valaxy project root used by the addon command. */
+  userRoot: string
+}
+
+/**
+ * Extend the CLI below the addon's package-derived command namespace.
+ *
+ * @experimental The addon CLI interface may evolve as more adapters adopt it.
+ */
+export type ValaxyAddonExtendCli = (cli: Argv<object>, context: ValaxyAddonCliContext) => void
 
 export interface ValaxyAddonResolver {
   name: string
@@ -12,11 +25,17 @@ export interface ValaxyAddonResolver {
   configFile?: string
   pkg: Record<string, any>
 
+  extendCli?: ValaxyAddonExtendCli
   setup?: (node: ValaxyNode) => void
 }
 
-export type ValaxyAddonLike = ValaxyAddon | false | null | undefined
-export type ValaxyAddons = (ValaxyAddon | string)[] | Record<string, ValaxyAddonLike>
+export type ValaxyNodeAddon = ValaxyAddon & {
+  extendCli?: ValaxyAddonExtendCli
+  setup?: ValaxyAddonResolver['setup']
+}
+
+export type ValaxyAddonLike = ValaxyNodeAddon | false | null | undefined
+export type ValaxyAddons = (ValaxyNodeAddon | string)[] | Record<string, ValaxyAddonLike>
 
 export type ValaxyAddonFn<ThemeConfig = DefaultTheme.Config> = (addonOptions: ValaxyAddonResolver, valaxyOptions: ResolvedValaxyOptions<ThemeConfig>) => ValaxyNodeConfig | Promise<ValaxyNodeConfig>
 export type ValaxyAddonExport<ThemeConfig = DefaultTheme.Config> = ValaxyNodeConfig<ThemeConfig> | ValaxyAddonFn<ThemeConfig>

--- a/packages/valaxy/types/addon.ts
+++ b/packages/valaxy/types/addon.ts
@@ -1,6 +1,8 @@
 // for client
 export interface ValaxyAddon<AddonOptions = Record<string, any>> {
   name: string
+  /** Whether the addon is enabled. @default true */
+  enable?: boolean
   /**
    * be global component
    */

--- a/test/addon-cli.test.ts
+++ b/test/addon-cli.test.ts
@@ -1,0 +1,112 @@
+import type { Argv } from 'yargs'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createCli } from '../packages/valaxy/node/cli'
+import {
+  collectAddonCliExtensions,
+  getAddonCommandName,
+  shouldResolveAddonCli,
+} from '../packages/valaxy/node/cli/addons'
+
+const tempRoots: string[] = []
+function extendCli(_cli: Argv<object>) {}
+
+async function createTempRoot() {
+  const root = await mkdtemp(join(tmpdir(), 'valaxy-addon-cli-'))
+  tempRoots.push(root)
+  return root
+}
+
+async function writeFixtureConfig(root: string) {
+  await writeFile(join(root, 'valaxy.config.ts'), `
+    import { writeFile } from 'node:fs/promises'
+    import { join } from 'node:path'
+
+    export default {
+      addons: [{
+        name: 'valaxy-addon-fixture',
+        enable: true,
+        extendCli(cli, { userRoot }) {
+          cli.command('ping', 'Write a marker', () => {}, async () => {
+            await writeFile(join(userRoot, 'addon-cli-marker.txt'), 'pong')
+          })
+        },
+      }],
+    }
+  `)
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map(root => rm(root, { force: true, recursive: true })))
+})
+
+describe('addon CLI namespace', () => {
+  it('derives the root command from unscoped and scoped addon package names', () => {
+    expect(getAddonCommandName('valaxy-addon-moments')).toBe('moments')
+    expect(getAddonCommandName('@example/valaxy-addon-moments')).toBe('moments')
+    expect(() => getAddonCommandName('example-moments')).toThrow('does not start with')
+  })
+
+  it('ignores disabled and string addons', () => {
+    expect(collectAddonCliExtensions([
+      'moments',
+      { enable: false, extendCli, name: 'valaxy-addon-disabled' },
+      { name: 'valaxy-addon-without-cli' },
+    ])).toEqual([])
+  })
+
+  it('rejects core command overrides and duplicate addon commands', () => {
+    expect(() => collectAddonCliExtensions([
+      { extendCli, name: 'valaxy-addon-build' },
+    ])).toThrow('reserved Valaxy command "build"')
+
+    expect(() => collectAddonCliExtensions([
+      { extendCli, name: 'valaxy-addon-moments' },
+      { extendCli, name: '@example/valaxy-addon-moments' },
+    ])).toThrow('both register the Valaxy command "moments"')
+  })
+
+  it('only resolves addons for a non-core, non-path command', () => {
+    expect(shouldResolveAddonCli(['moments', 'new'])).toBe(true)
+    expect(shouldResolveAddonCli(['build'])).toBe(false)
+    expect(shouldResolveAddonCli(['--help'])).toBe(false)
+    expect(shouldResolveAddonCli(['--port', '3000'])).toBe(false)
+    expect(shouldResolveAddonCli(['./moments'])).toBe(false)
+  })
+})
+
+describe('addon CLI dispatch', () => {
+  it('does not load project config for global help', async () => {
+    const root = await createTempRoot()
+    await writeFile(join(root, 'valaxy.config.ts'), 'throw new Error("global help loaded project config")\n')
+
+    const cli = await createCli(['--help'], { userRoot: root })
+    await expect(cli.getHelp()).resolves.not.toContain('fixture')
+  })
+
+  it('loads an enabled addon and dispatches inside its namespace', async () => {
+    const root = await createTempRoot()
+    await writeFixtureConfig(root)
+
+    const cli = await createCli(['fixture', 'ping'], { userRoot: root })
+    await cli.exitProcess(false).parseAsync()
+
+    await expect(readFile(join(root, 'addon-cli-marker.txt'), 'utf-8')).resolves.toBe('pong')
+  })
+
+  it('shows namespace help when no addon subcommand is provided', async () => {
+    const root = await createTempRoot()
+    await writeFixtureConfig(root)
+    const output: string[] = []
+    const log = vi.spyOn(console, 'log').mockImplementation(message => output.push(String(message)))
+
+    const cli = await createCli(['fixture'], { userRoot: root })
+    await cli.exitProcess(false).parseAsync()
+
+    log.mockRestore()
+    expect(output.join('\n')).toContain('valaxy fixture <command>')
+    expect(output.join('\n')).toContain('ping')
+  })
+})


### PR DESCRIPTION
## Summary

- add an experimental `extendCli` hook to configured and enabled addons
- derive a reserved addon command namespace from the package name
- reject core-command overrides and duplicate addon namespaces
- load addon configuration only when dispatching a possible addon command
- document addon CLI authoring and namespace constraints

This provides the Core prerequisite for #728, which will keep the Moments-specific `new` command inside `valaxy-addon-moments`.

## Verification

- `pnpm exec vitest run test/addon-cli.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm run build:valaxy`